### PR TITLE
feature/#47 JaCoCo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '2.7.7'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
@@ -49,6 +50,7 @@ ext {
 test {
     useJUnitPlatform()
     outputs.dir snippetsDir
+    finalizedBy jacocoTestReport
 }
 
 asciidoctor {
@@ -77,3 +79,19 @@ build {
     dependsOn copyDocument
 }
 /******* End Spring Rest Docs *******/
+
+/******* Start JaCoCo *******/
+jacoco {
+    toolVersion = "0.8.8"
+}
+
+jacocoTestReport {
+    reports {
+        html.enabled true
+        xml.enabled false
+        csv.enabled false
+    }
+
+    dependsOn test
+}
+/******* End JaCoCo *******/


### PR DESCRIPTION
## 🔥 Related Issue

close: #47

## 📝 Description

```
./gradlew --console verbose test
```

- 터미널에서 위의 명령어를 통해 실행합니다.
- `--console verbose`는 어떤 `task`가 실행되는지 확인하기 위한 옵션입니다.
- `test` 작업이 끝나고 자동으로 커버리지 문서가 실행되도록 되어있기에 `test` 작업을 실행합니다.
- 테스트가 정상적으로 수행되어야만 커버리지 문서가 정상적으로 생성됩니다.
- `build/reports/jacoco/test/html/index.html` 파일을 통해 커버리지 문서를 확인할 수 있습니다.

## 🌟 Review

테스트 커버리지를 높이기 위해 테스트 코드 작성을 열심히 해봅시다!