### PR TITLE
Feature/#57 썸네일 유틸리티 save() 메서드 인자가 null일 경우를 대비한다.

### DIFF
--- a/src/docs/user/user.adoc
+++ b/src/docs/user/user.adoc
@@ -54,3 +54,27 @@ include::{snippets}/user-delete/http-request.adoc[]
 ==== Response
 
 include::{snippets}/user-delete/http-response.adoc[]
+
+== *프로필 수정*
+
+NOTE: Authorization 헤더에 자신의 JWT access token이 필요합니다.
+
+=== 요청
+
+==== Request
+
+include::{snippets}/modify-profile/http-request.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/modify-profile/request-parameters.adoc[]
+
+==== Request Parts
+
+include::{snippets}/modify-profile/request-parts.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/modify-profile/http-response.adoc[]

--- a/src/docs/user/user.adoc
+++ b/src/docs/user/user.adoc
@@ -63,18 +63,18 @@ NOTE: Authorization 헤더에 자신의 JWT access token이 필요합니다.
 
 ==== Request
 
-include::{snippets}/modify-profile/http-request.adoc[]
+include::{snippets}/update-profile/http-request.adoc[]
 
 ==== Path Parameters
 
-include::{snippets}/modify-profile/request-parameters.adoc[]
+include::{snippets}/update-profile/request-parameters.adoc[]
 
 ==== Request Parts
 
-include::{snippets}/modify-profile/request-parts.adoc[]
+include::{snippets}/update-profile/request-parts.adoc[]
 
 === 응답
 
 ==== Response
 
-include::{snippets}/modify-profile/http-response.adoc[]
+include::{snippets}/update-profile/http-response.adoc[]

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/api/UserController.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/api/UserController.java
@@ -2,6 +2,7 @@ package com.dinosaur.foodbowl.domain.user.api;
 
 import com.dinosaur.foodbowl.domain.user.application.DeleteAccountService;
 import com.dinosaur.foodbowl.domain.user.application.signup.SignUpService;
+import com.dinosaur.foodbowl.domain.user.dto.request.UpdateProfileRequestDto;
 import com.dinosaur.foodbowl.domain.user.dto.request.SignUpRequestDto;
 import com.dinosaur.foodbowl.domain.user.dto.response.SignUpResponseDto;
 import java.net.URI;

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/api/UserController.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/api/UserController.java
@@ -6,6 +6,8 @@ import com.dinosaur.foodbowl.domain.user.application.signup.SignUpService;
 import com.dinosaur.foodbowl.domain.user.dto.request.SignUpRequestDto;
 import com.dinosaur.foodbowl.domain.user.dto.request.UpdateProfileRequestDto;
 import com.dinosaur.foodbowl.domain.user.dto.response.SignUpResponseDto;
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.global.util.auth.AuthUtil;
 import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class UserController {
   private final SignUpService signUpService;
   private final DeleteAccountService deleteAccountService;
   private final UpdateProfileService updateProfileService;
+  private final AuthUtil authUtil;
 
   @PostMapping("/sign-up")
   public ResponseEntity<SignUpResponseDto> signUp(@Valid @ModelAttribute SignUpRequestDto request) {
@@ -36,7 +39,8 @@ public class UserController {
 
   @DeleteMapping
   public ResponseEntity<Void> deleteAccount() {
-    deleteAccountService.deleteMySelf();
+    User me = authUtil.getUserByJWT();
+    deleteAccountService.deleteMySelf(me);
     return ResponseEntity.status(HttpStatus.NO_CONTENT)
         .build();
   }
@@ -44,7 +48,8 @@ public class UserController {
   @PatchMapping
   public ResponseEntity<Void> updateProfile(
       @ModelAttribute @Valid UpdateProfileRequestDto requestDto) {
-    long userId = updateProfileService.updateProfile(requestDto);
+    User me = authUtil.getUserByJWT();
+    long userId = updateProfileService.updateProfile(me, requestDto);
     return ResponseEntity.status(HttpStatus.NO_CONTENT)
         .location(URI.create("/users/" + userId))
         .build();

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/api/UserController.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/api/UserController.java
@@ -1,9 +1,10 @@
 package com.dinosaur.foodbowl.domain.user.api;
 
 import com.dinosaur.foodbowl.domain.user.application.DeleteAccountService;
+import com.dinosaur.foodbowl.domain.user.application.UpdateProfileService;
 import com.dinosaur.foodbowl.domain.user.application.signup.SignUpService;
-import com.dinosaur.foodbowl.domain.user.dto.request.UpdateProfileRequestDto;
 import com.dinosaur.foodbowl.domain.user.dto.request.SignUpRequestDto;
+import com.dinosaur.foodbowl.domain.user.dto.request.UpdateProfileRequestDto;
 import com.dinosaur.foodbowl.domain.user.dto.response.SignUpResponseDto;
 import java.net.URI;
 import javax.validation.Valid;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +25,7 @@ public class UserController {
 
   private final SignUpService signUpService;
   private final DeleteAccountService deleteAccountService;
+  private final UpdateProfileService updateProfileService;
 
   @PostMapping("/sign-up")
   public ResponseEntity<SignUpResponseDto> signUp(@Valid @ModelAttribute SignUpRequestDto request) {
@@ -35,6 +38,15 @@ public class UserController {
   public ResponseEntity<Void> deleteAccount() {
     deleteAccountService.deleteMySelf();
     return ResponseEntity.status(HttpStatus.NO_CONTENT)
+        .build();
+  }
+
+  @PatchMapping
+  public ResponseEntity<Void> updateProfile(
+      @ModelAttribute @Valid UpdateProfileRequestDto requestDto) {
+    long userId = updateProfileService.updateProfile(requestDto);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT)
+        .location(URI.create("/users/" + userId))
         .build();
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/application/DeleteAccountService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/application/DeleteAccountService.java
@@ -2,7 +2,6 @@ package com.dinosaur.foodbowl.domain.user.application;
 
 import com.dinosaur.foodbowl.domain.user.dao.UserRepository;
 import com.dinosaur.foodbowl.domain.user.entity.User;
-import com.dinosaur.foodbowl.global.util.auth.AuthUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,12 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class DeleteAccountService {
 
-  private final AuthUtil authUtil;
   private final UserRepository userRepository;
 
   @Transactional
-  public void deleteMySelf() {
-    User me = authUtil.getUserByJWT();
+  public void deleteMySelf(User me) {
     userRepository.delete(me);
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
@@ -4,6 +4,7 @@ import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.dto.request.UpdateProfileRequestDto;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailUtil;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,16 +19,15 @@ public class UpdateProfileService {
 
   @Transactional
   public long updateProfile(User me, UpdateProfileRequestDto requestDto) {
-    Thumbnail newThumbnail = saveThumbnailIfExist(requestDto.getThumbnail());
-    me.updateProfile(newThumbnail, requestDto.getIntroduce());
+    Optional<Thumbnail> newThumbnail = saveThumbnailIfExist(requestDto.getThumbnail());
+    me.updateProfile(newThumbnail.orElse(null), requestDto.getIntroduce());
     return me.getId();
   }
 
-  private Thumbnail saveThumbnailIfExist(MultipartFile thumbnail) {
-    Thumbnail newThumbnail = null;
-    if (thumbnail != null) {
-      newThumbnail = thumbnailUtil.save(thumbnail);
+  private Optional<Thumbnail> saveThumbnailIfExist(MultipartFile thumbnail) {
+    if (thumbnail == null) {
+      return Optional.empty();
     }
-    return newThumbnail;
+    return Optional.of(thumbnailUtil.save(thumbnail));
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
@@ -20,12 +20,16 @@ public class UpdateProfileService {
   @Transactional
   public long updateProfile(UpdateProfileRequestDto requestDto) {
     User me = authUtil.getUserByJWT();
-    Thumbnail newThumbnail = null;
-    try {
-      newThumbnail = thumbnailUtil.save(requestDto.getThumbnail());
-    } catch (RuntimeException ignore) {
-    }
+    Thumbnail newThumbnail = getThumbnail(requestDto);
     me.updateProfile(newThumbnail, requestDto.getIntroduce());
     return me.getId();
+  }
+
+  private Thumbnail getThumbnail(UpdateProfileRequestDto requestDto) {
+    Thumbnail newThumbnail = null;
+    if (requestDto.getThumbnail() != null) {
+      newThumbnail = thumbnailUtil.save(requestDto.getThumbnail());
+    }
+    return newThumbnail;
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
@@ -1,0 +1,31 @@
+package com.dinosaur.foodbowl.domain.user.application;
+
+import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
+import com.dinosaur.foodbowl.domain.user.dto.request.UpdateProfileRequestDto;
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.global.util.auth.AuthUtil;
+import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UpdateProfileService {
+
+  private final AuthUtil authUtil;
+  private final ThumbnailUtil thumbnailUtil;
+
+  @Transactional
+  public long updateProfile(UpdateProfileRequestDto requestDto) {
+    User me = authUtil.getUserByJWT();
+    Thumbnail newThumbnail = null;
+    try {
+      newThumbnail = thumbnailUtil.save(requestDto.getThumbnail());
+    } catch (RuntimeException ignore) {
+    }
+    me.updateProfile(newThumbnail, requestDto.getIntroduce());
+    return me.getId();
+  }
+}

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
@@ -3,7 +3,6 @@ package com.dinosaur.foodbowl.domain.user.application;
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.dto.request.UpdateProfileRequestDto;
 import com.dinosaur.foodbowl.domain.user.entity.User;
-import com.dinosaur.foodbowl.global.util.auth.AuthUtil;
 import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,12 +14,10 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional(readOnly = true)
 public class UpdateProfileService {
 
-  private final AuthUtil authUtil;
   private final ThumbnailUtil thumbnailUtil;
 
   @Transactional
-  public long updateProfile(UpdateProfileRequestDto requestDto) {
-    User me = authUtil.getUserByJWT();
+  public long updateProfile(User me, UpdateProfileRequestDto requestDto) {
     Thumbnail newThumbnail = saveThumbnailIfExist(requestDto.getThumbnail());
     me.updateProfile(newThumbnail, requestDto.getIntroduce());
     return me.getId();

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
@@ -8,6 +8,7 @@ import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -20,15 +21,15 @@ public class UpdateProfileService {
   @Transactional
   public long updateProfile(UpdateProfileRequestDto requestDto) {
     User me = authUtil.getUserByJWT();
-    Thumbnail newThumbnail = getThumbnail(requestDto);
+    Thumbnail newThumbnail = saveThumbnailIfExist(requestDto.getThumbnail());
     me.updateProfile(newThumbnail, requestDto.getIntroduce());
     return me.getId();
   }
 
-  private Thumbnail getThumbnail(UpdateProfileRequestDto requestDto) {
+  private Thumbnail saveThumbnailIfExist(MultipartFile thumbnail) {
     Thumbnail newThumbnail = null;
-    if (requestDto.getThumbnail() != null) {
-      newThumbnail = thumbnailUtil.save(requestDto.getThumbnail());
+    if (thumbnail != null) {
+      newThumbnail = thumbnailUtil.save(thumbnail);
     }
     return newThumbnail;
   }

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/application/UpdateProfileService.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -19,15 +18,9 @@ public class UpdateProfileService {
 
   @Transactional
   public long updateProfile(User me, UpdateProfileRequestDto requestDto) {
-    Optional<Thumbnail> newThumbnail = saveThumbnailIfExist(requestDto.getThumbnail());
+    Optional<Thumbnail> newThumbnail = thumbnailUtil
+        .saveIfExist(requestDto.getThumbnail());
     me.updateProfile(newThumbnail.orElse(null), requestDto.getIntroduce());
     return me.getId();
-  }
-
-  private Optional<Thumbnail> saveThumbnailIfExist(MultipartFile thumbnail) {
-    if (thumbnail == null) {
-      return Optional.empty();
-    }
-    return Optional.of(thumbnailUtil.save(thumbnail));
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/application/signup/SignUpService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/application/signup/SignUpService.java
@@ -12,11 +12,11 @@ import com.dinosaur.foodbowl.domain.user.entity.role.Role.RoleType;
 import com.dinosaur.foodbowl.domain.user.exception.UserException;
 import com.dinosaur.foodbowl.global.config.security.JwtTokenProvider;
 import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailUtil;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -33,18 +33,10 @@ public class SignUpService {
     checkDuplicateLoginId(request.getLoginId());
     checkDuplicateNickname(request.getNickname());
 
-    Thumbnail userThumbnail = saveThumbnailIfExist(request.getThumbnail());
-    User user = userRepository.save(request.toEntity(userThumbnail, passwordEncoder));
+    Optional<Thumbnail> userThumbnail = thumbnailUtil.saveIfExist(request.getThumbnail());
+    User user = userRepository.save(request.toEntity(userThumbnail.orElse(null), passwordEncoder));
     String accessToken = jwtTokenProvider.createAccessToken(user.getId(), RoleType.ROLE_회원);
     return SignUpResponseDto.of(user, accessToken);
-  }
-
-  private Thumbnail saveThumbnailIfExist(MultipartFile thumbnail) {
-    Thumbnail userThumbnail = null;
-    if (thumbnail != null) {
-      userThumbnail = thumbnailUtil.save(thumbnail);
-    }
-    return userThumbnail;
   }
 
   private void checkDuplicateLoginId(String loginId) {

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/ProfileModifyRequestDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/ProfileModifyRequestDto.java
@@ -1,0 +1,20 @@
+package com.dinosaur.foodbowl.domain.user.dto.request;
+
+import static com.dinosaur.foodbowl.domain.user.entity.User.MAX_INTRODUCE_LENGTH;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileModifyRequestDto {
+
+  @Length(max = MAX_INTRODUCE_LENGTH)
+  private String introduce;
+  private MultipartFile thumbnail;
+}

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/SignUpRequestDto.java
@@ -16,7 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SignUpRequestDto {
 
   public static final String LOGIN_ID_INVALID = "로그인 아이디는 4~12자 영어, 숫자, '_'만 가능합니다.";

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/SignUpRequestDto.java
@@ -4,6 +4,7 @@ import static com.dinosaur.foodbowl.domain.user.entity.User.MAX_INTRODUCE_LENGTH
 
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.global.util.validator.image.ImageOrNull;
 import javax.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -30,6 +31,7 @@ public class SignUpRequestDto {
   private String nickname;
   @Length(max = MAX_INTRODUCE_LENGTH)
   private String introduce;
+  @ImageOrNull
   private MultipartFile thumbnail;
 
   public User toEntity(Thumbnail thumbnail, PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/UpdateProfileRequestDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/UpdateProfileRequestDto.java
@@ -12,7 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateProfileRequestDto {
 
   @Length(max = MAX_INTRODUCE_LENGTH)

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/UpdateProfileRequestDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/UpdateProfileRequestDto.java
@@ -12,7 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProfileModifyRequestDto {
+public class UpdateProfileRequestDto {
 
   @Length(max = MAX_INTRODUCE_LENGTH)
   private String introduce;

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/UpdateProfileRequestDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/dto/request/UpdateProfileRequestDto.java
@@ -2,6 +2,7 @@ package com.dinosaur.foodbowl.domain.user.dto.request;
 
 import static com.dinosaur.foodbowl.domain.user.entity.User.MAX_INTRODUCE_LENGTH;
 
+import com.dinosaur.foodbowl.global.util.validator.image.ImageOrNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,5 +17,6 @@ public class UpdateProfileRequestDto {
 
   @Length(max = MAX_INTRODUCE_LENGTH)
   private String introduce;
+  @ImageOrNull
   private MultipartFile thumbnail;
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/entity/User.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/entity/User.java
@@ -97,4 +97,13 @@ public class User extends BaseEntity {
         .role(Role.getRoleBy(roleType))
         .build());
   }
+
+  public void updateProfile(Thumbnail thumbnail, String introduce) {
+    if (thumbnail != null) {
+      this.thumbnail = thumbnail;
+    }
+    if (introduce != null) {
+      this.introduce = introduce;
+    }
+  }
 }

--- a/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
@@ -3,6 +3,7 @@ package com.dinosaur.foodbowl.global.util.thumbnail;
 import static com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailType.DEFAULT;
 
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
+import com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileUtil;
 import java.io.IOException;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
@@ -4,11 +4,23 @@ import static com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailType.DEFAULT;
 
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import java.io.IOException;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 public abstract class ThumbnailUtil {
+
+  /**
+   * @param thumbnail 이 {@code null}일 가능성이 있는 경우 이 메서드를 사용하시는 게 좋습니다.
+   * @return {@link Thumbnail} if null, {@code Optional.empty()}
+   */
+  public Optional<Thumbnail> saveIfExist(MultipartFile thumbnail) {
+    if (thumbnail == null) {
+      return Optional.empty();
+    }
+    return Optional.of(save(thumbnail));
+  }
 
   /**
    * 타입은 기본적으로 {@link  ThumbnailType#DEFAULT} 가 들어갑니다. 그 외에는 {@code @see}를 참고해주세요.
@@ -20,7 +32,7 @@ public abstract class ThumbnailUtil {
   }
 
   /**
-   * @param multipartFile 이미지 파일이어야 합니다.
+   * @param multipartFile {@code @NotNull} 이미지 파일이어야 합니다.
    * @return 썸네일 저장에 성공할 경우 {@link Thumbnail} 엔티티를 반환합니다.
    * @throws IllegalArgumentException 이미지 파일이 아니거나 파일 이름의 길이가 너무 길 경우 발생합니다.
    * @throws IOException              `ThumbnailUtil` 자체에 문제가 있을 경우 발생합니다.

--- a/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
@@ -60,4 +60,16 @@ public abstract class ThumbnailUtil {
   protected abstract void deleteFile(Thumbnail thumbnail);
 
   protected abstract void deleteEntity(Thumbnail thumbnail);
+
+  /**
+   * @param thumbnail 이 {@code null}일 가능성이 있는 경우 이 메서드를 사용하시는 게 좋습니다.
+   * @apiNote 썸네일이 null일 경우 아무 일도 하지 않습니다.
+   * @see ThumbnailFileUtil#deleteFileAndEntity(Thumbnail)
+   */
+  public void deleteFileAndEntityIfExist(Thumbnail thumbnail) {
+    if (thumbnail == null) {
+      return;
+    }
+    deleteFileAndEntity(thumbnail);
+  }
 }

--- a/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
@@ -14,39 +14,29 @@ import org.springframework.web.multipart.MultipartFile;
 public abstract class ThumbnailUtil {
 
   /**
-   * @param thumbnail 이 {@code null}일 가능성이 있는 경우 이 메서드를 사용하시는 게 좋습니다.
-   * @return {@link Thumbnail} if null, {@code Optional.empty()}
-   * @see ThumbnailFileUtil#save(MultipartFile, ThumbnailType)
+   * 타입은 기본적으로 {@link  ThumbnailType#DEFAULT} 가 들어갑니다. 그 외에는 {@code @see}를 참고해주세요.
+   *
+   * @see ThumbnailFileUtil#saveIfExist(MultipartFile, ThumbnailType)
    */
   public Optional<Thumbnail> saveIfExist(MultipartFile thumbnail) {
     return saveIfExist(thumbnail, DEFAULT);
   }
 
-  public Optional<Thumbnail> saveIfExist(MultipartFile thumbnail, @NonNull ThumbnailType type) {
-    if (thumbnail == null) {
-      return Optional.empty();
-    }
-    return Optional.of(save(thumbnail, type));
-  }
-
   /**
-   * 타입은 기본적으로 {@link  ThumbnailType#DEFAULT} 가 들어갑니다. 그 외에는 {@code @see}를 참고해주세요.
-   *
-   * @see ThumbnailFileUtil#save(MultipartFile, ThumbnailType)
-   */
-  public Thumbnail save(@NonNull MultipartFile multipartFile) {
-    return this.save(multipartFile, DEFAULT);
-  }
-
-  /**
-   * @param multipartFile {@code @NotNull} 이미지 파일이어야 합니다.
-   * @param type          {@code @NotNull}
-   * @return 썸네일 저장에 성공할 경우 {@link Thumbnail} 엔티티를 반환합니다.
+   * @param thumbnail 이미지 파일이어야 합니다. if null, return {@code Optional.empty()}
+   * @return 썸네일 저장에 성공할 경우 {@link Thumbnail} 엔티티를 담아서 반환합니다.
    * @throws IllegalArgumentException 이미지 파일이 아니거나 파일 이름의 길이가 너무 길 경우 발생합니다.
    * @throws NullPointerException     인자에 null이 포함되어 있을 경우 발생합니다.
    * @throws IOException              `ThumbnailUtil` 자체에 문제가 있을 경우 발생합니다.
    */
-  public abstract Thumbnail save(@NonNull MultipartFile multipartFile, @NonNull ThumbnailType type);
+  public Optional<Thumbnail> saveIfExist(MultipartFile thumbnail, @NonNull ThumbnailType type) {
+    if (thumbnail == null) {
+      return Optional.empty();
+    }
+    return Optional.of(this.save(thumbnail, type));
+  }
+
+  protected abstract Thumbnail save(@NonNull MultipartFile thumbnail, @NonNull ThumbnailType type);
 
   /**
    * @param thumbnail {@code @NotNull}

--- a/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
@@ -6,6 +6,7 @@ import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileUtil;
 import java.io.IOException;
 import java.util.Optional;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,12 +16,13 @@ public abstract class ThumbnailUtil {
   /**
    * @param thumbnail 이 {@code null}일 가능성이 있는 경우 이 메서드를 사용하시는 게 좋습니다.
    * @return {@link Thumbnail} if null, {@code Optional.empty()}
+   * @see ThumbnailFileUtil#save(MultipartFile, ThumbnailType)
    */
   public Optional<Thumbnail> saveIfExist(MultipartFile thumbnail) {
     return saveIfExist(thumbnail, DEFAULT);
   }
 
-  public Optional<Thumbnail> saveIfExist(MultipartFile thumbnail, ThumbnailType type) {
+  public Optional<Thumbnail> saveIfExist(MultipartFile thumbnail, @NonNull ThumbnailType type) {
     if (thumbnail == null) {
       return Optional.empty();
     }
@@ -32,22 +34,25 @@ public abstract class ThumbnailUtil {
    *
    * @see ThumbnailFileUtil#save(MultipartFile, ThumbnailType)
    */
-  public Thumbnail save(MultipartFile multipartFile) {
+  public Thumbnail save(@NonNull MultipartFile multipartFile) {
     return this.save(multipartFile, DEFAULT);
   }
 
   /**
    * @param multipartFile {@code @NotNull} 이미지 파일이어야 합니다.
+   * @param type          {@code @NotNull}
    * @return 썸네일 저장에 성공할 경우 {@link Thumbnail} 엔티티를 반환합니다.
    * @throws IllegalArgumentException 이미지 파일이 아니거나 파일 이름의 길이가 너무 길 경우 발생합니다.
+   * @throws NullPointerException     인자에 null이 포함되어 있을 경우 발생합니다.
    * @throws IOException              `ThumbnailUtil` 자체에 문제가 있을 경우 발생합니다.
    */
-  public abstract Thumbnail save(MultipartFile multipartFile, ThumbnailType type);
+  public abstract Thumbnail save(@NonNull MultipartFile multipartFile, @NonNull ThumbnailType type);
 
   /**
-   * 저장된 썸네일 파일과 Entity 모두 삭제합니다.
+   * @param thumbnail {@code @NotNull}
+   * @apiNote 저장된 썸네일 파일과 Entity 모두 삭제합니다.
    */
-  public void deleteFileAndEntity(Thumbnail thumbnail) {
+  public void deleteFileAndEntity(@NonNull Thumbnail thumbnail) {
     deleteEntity(thumbnail);
     deleteFile(thumbnail);
   }

--- a/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/ThumbnailUtil.java
@@ -16,10 +16,14 @@ public abstract class ThumbnailUtil {
    * @return {@link Thumbnail} if null, {@code Optional.empty()}
    */
   public Optional<Thumbnail> saveIfExist(MultipartFile thumbnail) {
+    return saveIfExist(thumbnail, DEFAULT);
+  }
+
+  public Optional<Thumbnail> saveIfExist(MultipartFile thumbnail, ThumbnailType type) {
     if (thumbnail == null) {
       return Optional.empty();
     }
-    return Optional.of(save(thumbnail));
+    return Optional.of(save(thumbnail, type));
   }
 
   /**

--- a/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileConstants.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileConstants.java
@@ -1,10 +1,10 @@
-package com.dinosaur.foodbowl.global.util.thumbnail;
+package com.dinosaur.foodbowl.global.util.thumbnail.file;
 
 import static java.io.File.separator;
 
 import org.springframework.core.io.ClassPathResource;
 
-class ThumbnailConstants {
+class ThumbnailFileConstants {
 
   public static final String ROOT_PATH = "static";
   public static final String RESOURCE_PATH = new ClassPathResource(ROOT_PATH).getPath() + separator;

--- a/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileDto.java
@@ -1,7 +1,7 @@
-package com.dinosaur.foodbowl.global.util.thumbnail;
+package com.dinosaur.foodbowl.global.util.thumbnail.file;
 
 import static com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail.MAX_PATH_LENGTH;
-import static com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailConstants.DEFAULT_THUMBNAIL_PATH;
+import static com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileConstants.DEFAULT_THUMBNAIL_PATH;
 import static java.io.File.separator;
 
 import java.io.BufferedInputStream;
@@ -19,7 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-class ThumbnailInfoDto {
+class ThumbnailFileDto {
 
   static {
     createDirectoryWhenIsNotExist(DEFAULT_THUMBNAIL_PATH);
@@ -28,12 +28,12 @@ class ThumbnailInfoDto {
   private final String fullPath;
   private final InputStream originalInputStream;
 
-  static ThumbnailInfoDto from(MultipartFile file) throws IOException {
+  static ThumbnailFileDto from(MultipartFile file) throws IOException {
     String thumbnailFullPath = generateThumbnailFullPath(file);
     checkThumbnailFullPathLength(thumbnailFullPath, file.getOriginalFilename());
     checkInvalidImageFile(file);
     InputStream inputStream = new BufferedInputStream(file.getInputStream());
-    return new ThumbnailInfoDto(thumbnailFullPath, inputStream);
+    return new ThumbnailFileDto(thumbnailFullPath, inputStream);
   }
 
   private static void checkThumbnailFullPathLength(String thumbnailFullPath, String fileName) {

--- a/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileUtil.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileUtil.java
@@ -1,9 +1,11 @@
-package com.dinosaur.foodbowl.global.util.thumbnail;
+package com.dinosaur.foodbowl.global.util.thumbnail.file;
 
-import static com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailConstants.ROOT_PATH;
+import static com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileConstants.ROOT_PATH;
 
 import com.dinosaur.foodbowl.domain.thumbnail.dao.ThumbnailRepository;
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
+import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailType;
+import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailUtil;
 import com.dinosaur.foodbowl.global.util.thumbnail.exception.ThumbnailException;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -37,16 +39,16 @@ public class ThumbnailFileUtil extends ThumbnailUtil {
   }
 
   private Thumbnail trySave(MultipartFile file, ThumbnailType type) throws IOException {
-    ThumbnailInfoDto thumbnail = ThumbnailInfoDto.from(file);
+    ThumbnailFileDto thumbnail = ThumbnailFileDto.from(file);
     tryResizingAndSave(thumbnail, type);
     return saveThumbnailEntity(thumbnail.getFullPath(), type);
   }
 
-  private static void tryResizingAndSave(ThumbnailInfoDto thumbnailInfoDto, ThumbnailType type)
+  private static void tryResizingAndSave(ThumbnailFileDto thumbnailFileDto, ThumbnailType type)
       throws IOException {
-    BufferedImage bufferedImage = ImageIO.read(thumbnailInfoDto.getOriginalInputStream());
+    BufferedImage bufferedImage = ImageIO.read(thumbnailFileDto.getOriginalInputStream());
     BufferedImage resizingBufferedImage = type.resizing(bufferedImage);
-    File thumbnail = new File(thumbnailInfoDto.getFullPath());
+    File thumbnail = new File(thumbnailFileDto.getFullPath());
     ImageIO.write(resizingBufferedImage, "jpeg", thumbnail);
   }
 

--- a/src/main/java/com/dinosaur/foodbowl/global/util/validator/image/ImageFileValidator.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/util/validator/image/ImageFileValidator.java
@@ -1,0 +1,40 @@
+package com.dinosaur.foodbowl.global.util.validator.image;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.imageio.ImageIO;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ImageFileValidator implements ConstraintValidator<ImageOrNull, MultipartFile> {
+
+  @Override
+  public void initialize(ImageOrNull constraintAnnotation) {
+  }
+
+  @Override
+  public boolean isValid(MultipartFile multipartFile, ConstraintValidatorContext context) {
+    if (multipartFile == null) {
+      return true;
+    }
+    if (isNotImageFile(multipartFile)) {
+      context.disableDefaultConstraintViolation();
+      context.buildConstraintViolationWithTemplate("이미지 파일이 아닙니다.")
+          .addConstraintViolation();
+
+      return false;
+    }
+    return true;
+  }
+
+  private boolean isNotImageFile(MultipartFile file) {
+    try {
+      InputStream originalInputStream = new BufferedInputStream(file.getInputStream());
+      return ImageIO.read(originalInputStream) == null;
+    } catch (IOException e) {
+      return true;
+    }
+  }
+}

--- a/src/main/java/com/dinosaur/foodbowl/global/util/validator/image/ImageOrNull.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/util/validator/image/ImageOrNull.java
@@ -1,0 +1,20 @@
+package com.dinosaur.foodbowl.global.util.validator.image;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {ImageFileValidator.class})
+public @interface ImageOrNull {
+
+  String message() default "Invalid image file";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/com/dinosaur/foodbowl/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/user/api/UserControllerTest.java
@@ -334,7 +334,7 @@ class UserControllerTest extends ControllerTest {
 
   @Nested
   @DisplayName("프로필 수정")
-  class ModifyProfile {
+  class UpdateProfile {
 
     private final Long userId = 1L;
     private final String userToken = jwtTokenProvider.createAccessToken(userId, RoleType.ROLE_회원);
@@ -344,7 +344,7 @@ class UserControllerTest extends ControllerTest {
     private MultiValueMap<String, String> params;
 
     @BeforeEach
-    void setUpModifyProfile() throws IOException {
+    void setup() throws IOException {
       thumbnail = getThumbnailFile();
       params = new LinkedMultiValueMap<>();
       params.add("introduce", validIntroduce);
@@ -354,10 +354,10 @@ class UserControllerTest extends ControllerTest {
     @DisplayName("썸네일과 소개글 모두 포함되어 있어도 프로필 수정은 성공한다.")
     void should_successfully_when_validRequest() throws Exception {
       mockUpdateProfileService();
-      callModifyProfileApi(thumbnail)
+      callUpdateProfileApi(thumbnail)
           .andExpect(status().isNoContent())
           .andExpect(header().string("location", "/users/" + userId))
-          .andDo(document("modify-profile",
+          .andDo(document("update-profile",
               requestParameters(
                   parameterWithName("introduce")
                       .description("수정할 유저 소개 (최대 가능 길이 :" + MAX_INTRODUCE_LENGTH)
@@ -373,7 +373,7 @@ class UserControllerTest extends ControllerTest {
     @DisplayName("수정할 썸네일이 없어도 프로필 수정은 성공한다.")
     void should_successfully_when_nullThumbnail() throws Exception {
       mockUpdateProfileService();
-      callModifyProfileApiWithoutThumbnail()
+      callUpdateProfileApiWithoutThumbnail()
           .andExpect(status().isNoContent())
           .andExpect(header().string("location", "/users/" + userId));
     }
@@ -382,7 +382,7 @@ class UserControllerTest extends ControllerTest {
     @DisplayName("수정할 소개글이 없어도 프로필 수정은 성공한다.")
     void should_successfully_when_nullIntroduce() throws Exception {
       mockUpdateProfileService();
-      callModifyProfileApi(thumbnail)
+      callUpdateProfileApi(thumbnail)
           .andExpect(status().isNoContent())
           .andExpect(header().string("location", "/users/" + userId));
     }
@@ -392,7 +392,7 @@ class UserControllerTest extends ControllerTest {
     void should_successfully_when_nullEverything() throws Exception {
       params.set("introduce", null);
       mockUpdateProfileService();
-      callModifyProfileApiWithoutThumbnail()
+      callUpdateProfileApiWithoutThumbnail()
           .andExpect(status().isNoContent())
           .andExpect(header().string("location", "/users/" + userId));
     }
@@ -402,7 +402,7 @@ class UserControllerTest extends ControllerTest {
     void should_400BadRequest_when_tooLongIntroduce() throws Exception {
       params.set("introduce", "a".repeat(MAX_INTRODUCE_LENGTH + 1));
       mockUpdateProfileService();
-      callModifyProfileApi(thumbnail)
+      callUpdateProfileApi(thumbnail)
           .andExpect(status().isBadRequest());
     }
 
@@ -410,7 +410,7 @@ class UserControllerTest extends ControllerTest {
     @DisplayName("썸네일이 이미지가 아닐 경우 프로필 수정은 실패한다.")
     void should_400BadRequest_when_thumbnailIsNotImage() throws Exception {
       mockUpdateProfileService();
-      callModifyProfileApi(getFakeImageFile())
+      callUpdateProfileApi(getFakeImageFile())
           .andExpect(status().isBadRequest());
     }
 
@@ -418,7 +418,7 @@ class UserControllerTest extends ControllerTest {
       when(updateProfileService.updateProfile(any())).thenReturn(userId);
     }
 
-    private ResultActions callModifyProfileApi(MockMultipartFile thumbnail) throws Exception {
+    private ResultActions callUpdateProfileApi(MockMultipartFile thumbnail) throws Exception {
       return mockMvc.perform(multipart("/users")
           .file(thumbnail)
           .header("Authorization", userToken)
@@ -430,7 +430,7 @@ class UserControllerTest extends ControllerTest {
           }));
     }
 
-    private ResultActions callModifyProfileApiWithoutThumbnail() throws Exception {
+    private ResultActions callUpdateProfileApiWithoutThumbnail() throws Exception {
       return mockMvc.perform(multipart("/users")
           .header("Authorization", userToken)
           .params(params)

--- a/src/test/java/com/dinosaur/foodbowl/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/user/api/UserControllerTest.java
@@ -346,7 +346,7 @@ class UserControllerTest extends ControllerTest {
     @DisplayName("썸네일과 소개글 모두 포함되어 있어도 프로필 수정은 성공한다.")
     void should_successfully_when_validRequest() throws Exception {
       mockUpdateProfileService();
-      callModifyProfileApi()
+      callModifyProfileApi(thumbnail)
           .andExpect(status().isNoContent())
           .andExpect(header().string("location", "/users/" + userId))
           .andDo(document("modify-profile",
@@ -374,7 +374,7 @@ class UserControllerTest extends ControllerTest {
     @DisplayName("수정할 소개글이 없어도 프로필 수정은 성공한다.")
     void should_successfully_when_nullIntroduce() throws Exception {
       mockUpdateProfileService();
-      callModifyProfileApi()
+      callModifyProfileApi(thumbnail)
           .andExpect(status().isNoContent())
           .andExpect(header().string("location", "/users/" + userId));
     }
@@ -394,7 +394,7 @@ class UserControllerTest extends ControllerTest {
     void should_successfully_when_tooLongIntroduce() throws Exception {
       params.set("introduce", "a".repeat(MAX_INTRODUCE_LENGTH + 1));
       mockUpdateProfileService();
-      callModifyProfileApi()
+      callModifyProfileApi(thumbnail)
           .andExpect(status().isBadRequest());
     }
 
@@ -402,7 +402,7 @@ class UserControllerTest extends ControllerTest {
       when(updateProfileService.updateProfile(any())).thenReturn(userId);
     }
 
-    private ResultActions callModifyProfileApi() throws Exception {
+    private ResultActions callModifyProfileApi(MockMultipartFile thumbnail) throws Exception {
       return mockMvc.perform(multipart("/users")
           .file(thumbnail)
           .header("Authorization", userToken)

--- a/src/test/java/com/dinosaur/foodbowl/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/user/api/UserControllerTest.java
@@ -398,6 +398,14 @@ class UserControllerTest extends ControllerTest {
           .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("썸네일이 이미지가 아닐 경우 프로필 수정은 실패한다.")
+    void should_400BadRequest_when_thumbnailIsNotImage() throws Exception {
+      mockUpdateProfileService();
+      callModifyProfileApi(getFakeImageFile())
+          .andExpect(status().isBadRequest());
+    }
+
     private void mockUpdateProfileService() {
       when(updateProfileService.updateProfile(any())).thenReturn(userId);
     }
@@ -430,5 +438,11 @@ class UserControllerTest extends ControllerTest {
     return new MockMultipartFile("thumbnail",
         "testImage_210x210.png", "image/png",
         new FileInputStream("src/test/resources/images/testImage_1x1.png"));
+  }
+
+  private MockMultipartFile getFakeImageFile() throws IOException {
+    return new MockMultipartFile("thumbnail",
+        "fakeImage.png", "image/png",
+        new FileInputStream("src/test/resources/images/fakeImage.png"));
   }
 }

--- a/src/test/java/com/dinosaur/foodbowl/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/user/api/UserControllerTest.java
@@ -391,7 +391,7 @@ class UserControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("소개글이 너무 길 경우 프로필 수정은 실패한다.")
-    void should_successfully_when_tooLongIntroduce() throws Exception {
+    void should_400BadRequest_when_tooLongIntroduce() throws Exception {
       params.set("introduce", "a".repeat(MAX_INTRODUCE_LENGTH + 1));
       mockUpdateProfileService();
       callModifyProfileApi(thumbnail)

--- a/src/test/java/com/dinosaur/foodbowl/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/user/api/UserControllerTest.java
@@ -391,8 +391,9 @@ class UserControllerTest extends ControllerTest {
 
     private ResultActions callModifyProfileApi(MockMultipartFile thumbnail,
         MultiValueMap<String, String> params) throws Exception {
-      return mockMvc.perform(multipart("/users/{userId}", userId)
+      return mockMvc.perform(multipart("/users")
           .file(thumbnail)
+          .header("Authorization", userToken)
           .params(params)
           .contentType(MediaType.MULTIPART_FORM_DATA)
           .with(request -> {

--- a/src/test/java/com/dinosaur/foodbowl/domain/user/dao/UserRepositoryTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/user/dao/UserRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.dinosaur.foodbowl.domain.thumbnail.dao.ThumbnailRepository;
+import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.domain.user.entity.role.Role.RoleType;
 import com.dinosaur.foodbowl.global.dao.RepositoryTest;
@@ -12,9 +13,11 @@ import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailFileUtil;
 import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailUtil;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.UUID;
 import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -179,6 +182,100 @@ class UserRepositoryTest extends RepositoryTest {
       em.flush();
       em.clear();
       return userWithThumbnail;
+    }
+
+    private MockMultipartFile getThumbnailFile() throws IOException {
+      return new MockMultipartFile("thumbnail",
+          "testImage_1x1.png", "image/png",
+          new FileInputStream("src/test/resources/images/testImage_1x1.png"));
+    }
+
+    private String getUserThumbnailPath(User userWithThumbnail) {
+      return userWithThumbnail.getThumbnailURL()
+          .orElseThrow();
+    }
+  }
+
+  @Nested
+  @DisplayName("유저 프로필 업데이트")
+  class UserUpdateProfileTest {
+
+    @Test
+    @DisplayName("썸네일이 null일 경우 썸네일은 바뀌어선 안된다.")
+    void should_notChangeThumbnail_when_nullThumbnail() throws IOException {
+      User beforeUser = generateUser();
+      String newIntroduce = "newIntroduce";
+
+      whenUpdateUser(beforeUser, null, newIntroduce);
+
+      checkUserUpdated(beforeUser, beforeUser.getThumbnailURL(), newIntroduce);
+      checkThumbnailUpdated(beforeUser);
+    }
+
+    @Test
+    @DisplayName("소개가 null일 경우 소개는 바뀌어선 안된다.")
+    void should_notChangeThumbnail_when_nullIntroduce() throws IOException {
+      User beforeUser = generateUser();
+      Thumbnail newThumbnail = generateThumbnail();
+
+      whenUpdateUser(beforeUser, newThumbnail, null);
+
+      checkUserUpdated(beforeUser, Optional.of(newThumbnail.getPath()), beforeUser.getIntroduce());
+      checkThumbnailUpdated(beforeUser);
+    }
+
+    @Test
+    @DisplayName("썸네일과 소개가 null일 경우 둘 다 바뀌어선 안된다.")
+    void should_notChangeThumbnail_when_nullEverything() throws IOException {
+      User beforeUser = generateUser();
+
+      whenUpdateUser(beforeUser, null, null);
+
+      checkUserUpdated(beforeUser, beforeUser.getThumbnailURL(), beforeUser.getIntroduce());
+      checkThumbnailUpdated(beforeUser);
+    }
+
+    private void checkUserUpdated(User beforeUser, Optional<String> newThumbnailPath,
+        String newIntroduce) {
+      User findUser = userRepository.findById(beforeUser.getId()).orElseThrow();
+      assertThat(findUser).isEqualTo(beforeUser);
+      assertThat(findUser.getIntroduce()).isEqualTo(newIntroduce);
+      assertThat(findUser.getLoginId()).isEqualTo(beforeUser.getLoginId());
+      assertThat(findUser.getNickname()).isEqualTo(beforeUser.getNickname());
+      assertThat(findUser.getPassword()).isEqualTo(beforeUser.getPassword());
+      assertThat(findUser.getThumbnailURL()).hasValue(newThumbnailPath.orElseThrow());
+    }
+
+    private void checkThumbnailUpdated(User userWithThumbnail) {
+      String userThumbnailPath = getUserThumbnailPath(userWithThumbnail);
+      assertThat(thumbnailRepository.findByPath(userThumbnailPath)).isNotEmpty();
+      assertThat(thumbnailRepository.findByPath(userThumbnailPath).orElseThrow().getPath())
+          .isEqualTo(userThumbnailPath);
+    }
+
+    private void whenUpdateUser(User user, Thumbnail thumbnail, String newIntroduce) {
+      user.updateProfile(thumbnail, newIntroduce);
+      em.flush();
+      em.clear();
+    }
+
+    private User generateUser() throws IOException {
+      Thumbnail thumbnail = generateThumbnail();
+      User userWithThumbnail = User.builder()
+          .loginId(getRandomUUIDLengthWith(MAX_LOGIN_ID_LENGTH))
+          .nickname(getRandomUUIDLengthWith(MAX_NICKNAME_LENGTH))
+          .password(getRandomUUIDLengthWith(MAX_PASSWORD_LENGTH))
+          .introduce(getRandomUUIDLengthWith(MAX_INTRODUCE_LENGTH))
+          .thumbnail(thumbnail)
+          .build();
+      userWithThumbnail = userRepository.save(userWithThumbnail);
+      return userWithThumbnail;
+    }
+
+    private Thumbnail generateThumbnail() throws IOException {
+      final ThumbnailUtil thumbnailUtil = new ThumbnailFileUtil(thumbnailRepository);
+      Thumbnail thumbnail = thumbnailUtil.save(getThumbnailFile());
+      return thumbnail;
     }
 
     private MockMultipartFile getThumbnailFile() throws IOException {

--- a/src/test/java/com/dinosaur/foodbowl/domain/user/dao/UserRepositoryTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/user/dao/UserRepositoryTest.java
@@ -9,7 +9,7 @@ import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.domain.user.entity.role.Role.RoleType;
 import com.dinosaur.foodbowl.global.dao.RepositoryTest;
-import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailFileUtil;
+import com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileUtil;
 import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailUtil;
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/src/test/java/com/dinosaur/foodbowl/domain/user/dao/UserRepositoryTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/user/dao/UserRepositoryTest.java
@@ -9,8 +9,8 @@ import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.domain.user.entity.role.Role.RoleType;
 import com.dinosaur.foodbowl.global.dao.RepositoryTest;
-import com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileUtil;
 import com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailUtil;
+import com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileUtil;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Optional;
@@ -176,7 +176,7 @@ class UserRepositoryTest extends RepositoryTest {
           .nickname(getRandomUUIDLengthWith(MAX_NICKNAME_LENGTH))
           .password(getRandomUUIDLengthWith(MAX_PASSWORD_LENGTH))
           .introduce(getRandomUUIDLengthWith(MAX_INTRODUCE_LENGTH))
-          .thumbnail(thumbnailUtil.save(getThumbnailFile()))
+          .thumbnail(thumbnailUtil.saveIfExist(getThumbnailFile()).orElseThrow())
           .build();
       userWithThumbnail = userRepository.save(userWithThumbnail);
       em.flush();
@@ -274,7 +274,7 @@ class UserRepositoryTest extends RepositoryTest {
 
     private Thumbnail generateThumbnail() throws IOException {
       final ThumbnailUtil thumbnailUtil = new ThumbnailFileUtil(thumbnailRepository);
-      Thumbnail thumbnail = thumbnailUtil.save(getThumbnailFile());
+      Thumbnail thumbnail = thumbnailUtil.saveIfExist(getThumbnailFile()).orElseThrow();
       return thumbnail;
     }
 

--- a/src/test/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileDtoTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileDtoTest.java
@@ -1,15 +1,16 @@
-package com.dinosaur.foodbowl.global.util.thumbnail;
+package com.dinosaur.foodbowl.global.util.thumbnail.file;
 
 import static com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail.MAX_PATH_LENGTH;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileDto;
 import java.io.FileInputStream;
 import java.io.IOException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockMultipartFile;
 
-class ThumbnailInfoDtoTest {
+class ThumbnailFileDtoTest {
 
   @Nested
   class from {
@@ -19,7 +20,7 @@ class ThumbnailInfoDtoTest {
       final MockMultipartFile tooLongFileNameMultipartFile = new MockMultipartFile("image",
           "a".repeat(MAX_PATH_LENGTH) + ".png", "image/png",
           new FileInputStream("src/test/resources/images/testImage_210x210.png"));
-      assertThatThrownBy(() -> ThumbnailInfoDto.from(tooLongFileNameMultipartFile))
+      assertThatThrownBy(() -> ThumbnailFileDto.from(tooLongFileNameMultipartFile))
           .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -28,7 +29,7 @@ class ThumbnailInfoDtoTest {
       final MockMultipartFile fakeImageFile = new MockMultipartFile("image",
           "fakeImage.png", "image/png",
           new FileInputStream("src/test/resources/images/fakeImage.png"));
-      assertThatThrownBy(() -> ThumbnailInfoDto.from(fakeImageFile))
+      assertThatThrownBy(() -> ThumbnailFileDto.from(fakeImageFile))
           .isInstanceOf(IllegalArgumentException.class);
     }
   }

--- a/src/test/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileUtilTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileUtilTest.java
@@ -2,9 +2,9 @@ package com.dinosaur.foodbowl.global.util.thumbnail.file;
 
 import static com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileConstants.ROOT_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
-import com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileUtil;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import javax.imageio.ImageIO;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,6 +80,19 @@ class ThumbnailFileUtilTest {
       assertThat(image.getWidth()).isEqualTo(200);
 
       deleteTestFile(savedThumbnailEntity);
+    }
+
+    @Test
+    @DisplayName("썸네일 저장 시 파라미터가 null이면 NullPointerException을 발생시킨다.")
+    void should_throwNullPointerException_when_parameterIsNull() {
+      assertThatThrownBy(() -> thumbnailFileUtil.save(null))
+          .isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(() -> thumbnailFileUtil.save(null, null))
+          .isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(() -> thumbnailFileUtil.saveIfExist(validMultipartFile, null))
+          .isInstanceOf(NullPointerException.class);
+      assertThatThrownBy(() -> thumbnailFileUtil.deleteFileAndEntity(null))
+          .isInstanceOf(NullPointerException.class);
     }
   }
 }

--- a/src/test/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileUtilTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileUtilTest.java
@@ -1,9 +1,10 @@
-package com.dinosaur.foodbowl.global.util.thumbnail;
+package com.dinosaur.foodbowl.global.util.thumbnail.file;
 
-import static com.dinosaur.foodbowl.global.util.thumbnail.ThumbnailConstants.ROOT_PATH;
+import static com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileConstants.ROOT_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
+import com.dinosaur.foodbowl.global.util.thumbnail.file.ThumbnailFileUtil;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/test/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileUtilTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileUtilTest.java
@@ -28,9 +28,11 @@ class ThumbnailFileUtilTest {
   private ThumbnailFileUtil thumbnailFileUtil;
 
   @Nested
+  @DisplayName("썸네일 삭제 테스트")
   class deleteTest {
 
     @Test
+    @DisplayName("썸네일 파일이 존재할 경우 삭제는 성공해야 한다.")
     void should_deleteSuccessfully_when_existFile() throws IOException {
       MockMultipartFile validMultipartFile = new MockMultipartFile("image",
           "testImage_210x210.png", "image/png",
@@ -46,6 +48,7 @@ class ThumbnailFileUtilTest {
   }
 
   @Nested
+  @DisplayName("썸네일 저장 테스트")
   class SaveTest {
 
     private final MockMultipartFile validMultipartFile = new MockMultipartFile("image",
@@ -56,19 +59,15 @@ class ThumbnailFileUtilTest {
     }
 
     @Test
+    @DisplayName("썸네일 파일이 유효한 경우 저장은 성공해야 한다.")
     void should_saveSuccessfully_when_validMultipartFile() {
       Thumbnail result = thumbnailFileUtil.save(validMultipartFile);
       assertThat(result).isNotNull();
       deleteTestFile(result);
     }
 
-    private void deleteTestFile(Thumbnail thumbnail) {
-      File thumbnailFile = new File(ROOT_PATH + thumbnail.getPath());
-      assertThat(thumbnailFile).exists();
-      assertThat(thumbnailFile.delete()).isTrue();
-    }
-
     @Test
+    @DisplayName("썸네일 파일이 유효한 경우 원하는 사이즈로 사이즈 변환에 성공해야 한다.")
     void should_resizingWell_when_validMultipartFile() throws IOException {
       Thumbnail savedThumbnailEntity = thumbnailFileUtil.save(validMultipartFile);
       File result = new File(ROOT_PATH + savedThumbnailEntity.getPath());
@@ -93,6 +92,12 @@ class ThumbnailFileUtilTest {
           .isInstanceOf(NullPointerException.class);
       assertThatThrownBy(() -> thumbnailFileUtil.deleteFileAndEntity(null))
           .isInstanceOf(NullPointerException.class);
+    }
+
+    private void deleteTestFile(Thumbnail thumbnail) {
+      File thumbnailFile = new File(ROOT_PATH + thumbnail.getPath());
+      assertThat(thumbnailFile).exists();
+      assertThat(thumbnailFile.delete()).isTrue();
     }
   }
 }

--- a/src/test/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileUtilTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/global/util/thumbnail/file/ThumbnailFileUtilTest.java
@@ -37,7 +37,7 @@ class ThumbnailFileUtilTest {
       MockMultipartFile validMultipartFile = new MockMultipartFile("image",
           "testImage_210x210.png", "image/png",
           new FileInputStream("src/test/resources/images/testImage_210x210.png"));
-      Thumbnail savedThumbnail = thumbnailFileUtil.save(validMultipartFile);
+      Thumbnail savedThumbnail = thumbnailFileUtil.saveIfExist(validMultipartFile).orElseThrow();
 
       assertThat(Files.exists(Path.of(ROOT_PATH + savedThumbnail.getPath()))).isTrue();
 
@@ -61,7 +61,7 @@ class ThumbnailFileUtilTest {
     @Test
     @DisplayName("썸네일 파일이 유효한 경우 저장은 성공해야 한다.")
     void should_saveSuccessfully_when_validMultipartFile() {
-      Thumbnail result = thumbnailFileUtil.save(validMultipartFile);
+      Thumbnail result = thumbnailFileUtil.saveIfExist(validMultipartFile).orElseThrow();
       assertThat(result).isNotNull();
       deleteTestFile(result);
     }
@@ -69,7 +69,8 @@ class ThumbnailFileUtilTest {
     @Test
     @DisplayName("썸네일 파일이 유효한 경우 원하는 사이즈로 사이즈 변환에 성공해야 한다.")
     void should_resizingWell_when_validMultipartFile() throws IOException {
-      Thumbnail savedThumbnailEntity = thumbnailFileUtil.save(validMultipartFile);
+      Thumbnail savedThumbnailEntity = thumbnailFileUtil.saveIfExist(validMultipartFile)
+          .orElseThrow();
       File result = new File(ROOT_PATH + savedThumbnailEntity.getPath());
 
       assertThat(result).exists();
@@ -82,11 +83,9 @@ class ThumbnailFileUtilTest {
     }
 
     @Test
-    @DisplayName("썸네일 저장 시 파라미터가 null이면 NullPointerException을 발생시킨다.")
+    @DisplayName("썸네일 저장 시 type이 null이면 NullPointerException을 발생시킨다.")
     void should_throwNullPointerException_when_parameterIsNull() {
-      assertThatThrownBy(() -> thumbnailFileUtil.save(null))
-          .isInstanceOf(NullPointerException.class);
-      assertThatThrownBy(() -> thumbnailFileUtil.save(null, null))
+      assertThatThrownBy(() -> thumbnailFileUtil.saveIfExist(null, null))
           .isInstanceOf(NullPointerException.class);
       assertThatThrownBy(() -> thumbnailFileUtil.saveIfExist(validMultipartFile, null))
           .isInstanceOf(NullPointerException.class);


### PR DESCRIPTION
## 🔥 Related Issue

close: #57

## 📝 Description

썸네일 저장 시 사용하는 `save() `메서드의 인자인 `multipartFile`이 `null`일 경우 이미지 파일이 아닙니다. 라는 에러 메시지가 나온다.

`null`이면 안되는 파라미터가 널일 경우 롬복의 `@NonNull` 어노테이션을 활용해 `NullPointerException`을 던져주도록 하고, JavaDoc에 명시해두었다.

```java
public Thumbnail save(MultipartFile multipartFile, ThumbnailType type);
```

## 🌟 Review

커밋은 8f2178dd5d2fdfdb4e8bf3e9a72ac4daaa36b5b4 여기서부터 보시면 됩니다.

---

> 썸네일 저장 시 `multipartFile`이 `null`일 경우 보내는 `Exception`을 `Exception Advice`가 잡아서 처리

위 내용은 유틸리티에서 일어나는 `Exception`을 잡는게 적절하지 않은 것 같아 사용하는 측에서 관리할 수 있도록 javadoc에 명시해두었다.