### PR TITLE
Feature/#79 닉네임 중복과 유효성을 검사하는 기능을 구현한다.

### DIFF
--- a/src/docs/asciidoc/user/user.adoc
+++ b/src/docs/asciidoc/user/user.adoc
@@ -13,6 +13,28 @@ endif::[]
 
 link:../foodbowl.html[API 목록으로 돌아가기]
 
+== *닉네임 유효성 및 중복 검사*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/nickname-check/http-request.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/nickname-check/query-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/nickname-check/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/nickname-check/response-fields.adoc[]
+
 == *회원가입*
 
 === 요청

--- a/src/main/java/com/dinosaur/foodbowl/domain/auth/api/AuthController.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/auth/api/AuthController.java
@@ -8,7 +8,6 @@ import com.dinosaur.foodbowl.domain.auth.application.AuthService;
 import com.dinosaur.foodbowl.domain.auth.application.TokenService;
 import com.dinosaur.foodbowl.domain.auth.dto.request.LoginRequestDto;
 import com.dinosaur.foodbowl.domain.auth.dto.request.SignUpRequestDto;
-import com.dinosaur.foodbowl.domain.auth.dto.response.CheckResponseDto;
 import com.dinosaur.foodbowl.domain.auth.dto.response.SignUpResponseDto;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.global.util.CookieUtils;
@@ -16,7 +15,6 @@ import com.dinosaur.foodbowl.global.util.resolver.LoginUser;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +22,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -60,12 +57,12 @@ public class AuthController {
         .body(signUpResponseDto);
   }
 
-  @GetMapping("/sign-up/check/nickname")
-  public ResponseEntity<CheckResponseDto> checkNickname(@RequestParam @NotNull String nickname) {
-    CheckResponseDto response = authService.checkNickname(nickname);
-
-    return ResponseEntity.ok(response);
-  }
+//  @GetMapping("/sign-up/check/nickname")
+//  public ResponseEntity<CheckResponseDto> checkNickname(@RequestParam @NotNull String nickname) {
+//    CheckResponseDto response = authService.checkNickname(nickname);
+//
+//    return ResponseEntity.ok(response);
+//  }
 
   @PostMapping("/log-in")
   public ResponseEntity<Void> login(@Valid @RequestBody LoginRequestDto loginRequestDto,

--- a/src/main/java/com/dinosaur/foodbowl/domain/auth/api/AuthController.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/auth/api/AuthController.java
@@ -8,6 +8,7 @@ import com.dinosaur.foodbowl.domain.auth.application.AuthService;
 import com.dinosaur.foodbowl.domain.auth.application.TokenService;
 import com.dinosaur.foodbowl.domain.auth.dto.request.LoginRequestDto;
 import com.dinosaur.foodbowl.domain.auth.dto.request.SignUpRequestDto;
+import com.dinosaur.foodbowl.domain.auth.dto.response.CheckResponseDto;
 import com.dinosaur.foodbowl.domain.auth.dto.response.SignUpResponseDto;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.global.util.CookieUtils;
@@ -15,6 +16,7 @@ import com.dinosaur.foodbowl.global.util.resolver.LoginUser;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -57,12 +60,12 @@ public class AuthController {
         .body(signUpResponseDto);
   }
 
-//  @GetMapping("/sign-up/check/nickname")
-//  public ResponseEntity<CheckResponseDto> checkNickname(@RequestParam @NotNull String nickname) {
-//    CheckResponseDto response = authService.checkNickname(nickname);
-//
-//    return ResponseEntity.ok(response);
-//  }
+  @GetMapping("/sign-up/check/nickname")
+  public ResponseEntity<CheckResponseDto> checkNickname(@RequestParam @NotNull String nickname) {
+    CheckResponseDto response = authService.checkNickname(nickname);
+
+    return ResponseEntity.ok(response);
+  }
 
   @PostMapping("/log-in")
   public ResponseEntity<Void> login(@Valid @RequestBody LoginRequestDto loginRequestDto,

--- a/src/main/java/com/dinosaur/foodbowl/domain/auth/api/AuthController.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/auth/api/AuthController.java
@@ -8,6 +8,7 @@ import com.dinosaur.foodbowl.domain.auth.application.AuthService;
 import com.dinosaur.foodbowl.domain.auth.application.TokenService;
 import com.dinosaur.foodbowl.domain.auth.dto.request.LoginRequestDto;
 import com.dinosaur.foodbowl.domain.auth.dto.request.SignUpRequestDto;
+import com.dinosaur.foodbowl.domain.auth.dto.response.CheckResponseDto;
 import com.dinosaur.foodbowl.domain.auth.dto.response.SignUpResponseDto;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.global.util.CookieUtils;
@@ -15,6 +16,7 @@ import com.dinosaur.foodbowl.global.util.resolver.LoginUser;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -55,6 +58,13 @@ public class AuthController {
 
     return ResponseEntity.created(URI.create("/users/" + signUpResponseDto.getUserId()))
         .body(signUpResponseDto);
+  }
+
+  @GetMapping("/sign-up/check/nickname")
+  public ResponseEntity<CheckResponseDto> checkNickname(@RequestParam @NotNull String nickname) {
+    CheckResponseDto response = authService.checkNickname(nickname);
+
+    return ResponseEntity.ok(response);
   }
 
   @PostMapping("/log-in")

--- a/src/main/java/com/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -12,6 +12,7 @@ import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.dao.UserFindDao;
 import com.dinosaur.foodbowl.domain.user.dao.UserRepository;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
 import com.dinosaur.foodbowl.global.error.BusinessException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,7 @@ public class AuthService {
   @Transactional
   public SignUpResponseDto signUp(SignUpRequestDto request) {
     checkDuplicateLoginId(request.getLoginId());
-    checkDuplicateNickname(request.getNickname());
+    checkDuplicateNickname(request.getNickname().getNickname());
 
     Optional<Thumbnail> userThumbnail = thumbnailUtil.saveIfExist(request.getThumbnail());
     User user = userRepository.save(request.toEntity(userThumbnail.orElse(null), passwordEncoder));
@@ -46,7 +47,7 @@ public class AuthService {
   }
 
   private void checkDuplicateNickname(String nickname) {
-    if (userRepository.existsByNickname(nickname)) {
+    if (userRepository.existsByNickname(Nickname.from(nickname))) {
       throw new BusinessException(nickname, "nickname", NICKNAME_DUPLICATE);
     }
   }

--- a/src/main/java/com/dinosaur/foodbowl/domain/auth/application/AuthService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/auth/application/AuthService.java
@@ -6,6 +6,7 @@ import static com.dinosaur.foodbowl.global.error.ErrorCode.PASSWORD_NOT_MATCH;
 
 import com.dinosaur.foodbowl.domain.auth.dto.request.LoginRequestDto;
 import com.dinosaur.foodbowl.domain.auth.dto.request.SignUpRequestDto;
+import com.dinosaur.foodbowl.domain.auth.dto.response.CheckResponseDto;
 import com.dinosaur.foodbowl.domain.auth.dto.response.SignUpResponseDto;
 import com.dinosaur.foodbowl.domain.thumbnail.ThumbnailUtil;
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
@@ -15,6 +16,7 @@ import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
 import com.dinosaur.foodbowl.global.error.BusinessException;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -60,5 +62,17 @@ public class AuthService {
     }
 
     return user.getId();
+  }
+
+  public CheckResponseDto checkNickname(final String nickname) {
+    if (!Pattern.matches(Nickname.PATTERN, nickname)) {
+      return CheckResponseDto.of(false, Nickname.NICKNAME_INVALID);
+    }
+
+    if (userRepository.existsByNickname(Nickname.from(nickname))) {
+      return CheckResponseDto.of(false, NICKNAME_DUPLICATE.getMessage());
+    }
+
+    return CheckResponseDto.of(true, "사용 가능한 닉네임입니다.");
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/auth/dto/AuthFieldError.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/auth/dto/AuthFieldError.java
@@ -4,7 +4,6 @@ public enum AuthFieldError {
 
   LOGIN_ID_INVALID(Message.LOGIN_ID_INVALID),
   PASSWORD_INVALID(Message.PASSWORD_INVALID),
-  NICKNAME_INVALID(Message.NICKNAME_INVALID),
   ;
 
   private final String message;
@@ -21,6 +20,5 @@ public enum AuthFieldError {
 
     public static final String LOGIN_ID_INVALID = "로그인 아이디는 4~12자 영어, 숫자, '_'만 가능합니다.";
     public static final String PASSWORD_INVALID = "비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다.";
-    public static final String NICKNAME_INVALID = "닉네임은 1~16자 한글, 영어, 숫자만 가능합니다.";
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/auth/dto/request/SignUpRequestDto.java
@@ -5,7 +5,9 @@ import static com.dinosaur.foodbowl.domain.user.entity.User.MAX_INTRODUCE_LENGTH
 
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
 import com.dinosaur.foodbowl.global.util.validator.image.ImageOrNull;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -25,15 +27,15 @@ public class SignUpRequestDto {
   private String loginId;
   @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$", message = Message.PASSWORD_INVALID)
   private String password;
-  @Pattern(regexp = "^[a-zA-Z0-9가-힣]{1,16}", message = Message.NICKNAME_INVALID)
-  private String nickname;
+  @Valid
+  private Nickname nickname;
   @Length(max = MAX_INTRODUCE_LENGTH)
   private String introduce;
   @ImageOrNull
   private MultipartFile thumbnail;
 
   @Builder
-  private SignUpRequestDto(String loginId, String password, String nickname,
+  private SignUpRequestDto(String loginId, String password, Nickname nickname,
       String introduce, MultipartFile thumbnail) {
     this.loginId = loginId;
     this.password = password;

--- a/src/main/java/com/dinosaur/foodbowl/domain/auth/dto/response/CheckResponseDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/auth/dto/response/CheckResponseDto.java
@@ -1,11 +1,27 @@
 package com.dinosaur.foodbowl.domain.auth.dto.response;
 
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CheckResponseDto {
 
   private boolean available;
   private String message;
+
+  @Builder
+  private CheckResponseDto(boolean available, String message) {
+    this.available = available;
+    this.message = message;
+  }
+
+  public static CheckResponseDto of(boolean available, String message) {
+    return CheckResponseDto.builder()
+        .available(available)
+        .message(message)
+        .build();
+  }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/auth/dto/response/CheckResponseDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/auth/dto/response/CheckResponseDto.java
@@ -1,0 +1,11 @@
+package com.dinosaur.foodbowl.domain.auth.dto.response;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CheckResponseDto {
+
+  private boolean available;
+  private String message;
+}

--- a/src/main/java/com/dinosaur/foodbowl/domain/auth/dto/response/SignUpResponseDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/auth/dto/response/SignUpResponseDto.java
@@ -1,6 +1,8 @@
 package com.dinosaur.foodbowl.domain.auth.dto.response;
 
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,7 +11,8 @@ public class SignUpResponseDto {
 
   private final Long userId;
   private final String loginId;
-  private final String nickname;
+  @JsonUnwrapped
+  private final Nickname nickname;
   private final String introduce;
   private final String thumbnailURL;
 
@@ -24,7 +27,7 @@ public class SignUpResponseDto {
   }
 
   @Builder
-  private SignUpResponseDto(Long userId, String loginId, String nickname, String introduce,
+  private SignUpResponseDto(Long userId, String loginId, Nickname nickname, String introduce,
       String thumbnailURL) {
     this.userId = userId;
     this.loginId = loginId;

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/dao/UserRepository.java
@@ -1,6 +1,7 @@
 package com.dinosaur.foodbowl.domain.user.dao;
 
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,7 +9,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   boolean existsByLoginId(String loginId);
 
-  boolean existsByNickname(String nickname);
+  boolean existsByNickname(Nickname nickname);
 
   Optional<User> findByLoginId(String loginId);
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/dto/response/ProfileResponseDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/dto/response/ProfileResponseDto.java
@@ -20,7 +20,7 @@ public class ProfileResponseDto {
       long postCount) {
     return ProfileResponseDto.builder()
         .userId(user.getId())
-        .nickname(user.getNickname())
+        .nickname(user.getNickname().getNickname())
         .introduce(user.getIntroduce())
         .followerCount(followerCount)
         .followingCount(followingCount)

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/entity/User.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/entity/User.java
@@ -9,8 +9,10 @@ import com.dinosaur.foodbowl.domain.follow.entity.Follow;
 import com.dinosaur.foodbowl.domain.post.entity.Post;
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.entity.Role.RoleType;
+import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
 import com.dinosaur.foodbowl.global.entity.BaseEntity;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -37,7 +39,6 @@ public class User extends BaseEntity {
 
   public static final int MAX_LOGIN_ID_LENGTH = 45;
   public static final int MAX_PASSWORD_LENGTH = 512;
-  public static final int MAX_NICKNAME_LENGTH = 45;
   public static final int MAX_INTRODUCE_LENGTH = 255;
 
   @Getter
@@ -59,8 +60,8 @@ public class User extends BaseEntity {
   private String password;
 
   @Getter
-  @Column(name = "nickname", nullable = false, unique = true, length = MAX_NICKNAME_LENGTH)
-  private String nickname;
+  @Embedded
+  private Nickname nickname;
 
   @Getter
   @Column(name = "introduce", length = MAX_INTRODUCE_LENGTH)
@@ -77,7 +78,7 @@ public class User extends BaseEntity {
   private final List<Post> posts = new ArrayList<>();
 
   @Builder
-  private User(Thumbnail thumbnail, String loginId, String password, String nickname,
+  private User(Thumbnail thumbnail, String loginId, String password, Nickname nickname,
       String introduce) {
     this.thumbnail = thumbnail;
     this.loginId = loginId;

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/entity/embedded/Nickname.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/entity/embedded/Nickname.java
@@ -1,0 +1,36 @@
+package com.dinosaur.foodbowl.domain.user.entity.embedded;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"nickname"}, callSuper = false)
+public class Nickname {
+
+  public static final int MAX_NICKNAME_LENGTH = 45;
+  public static final String pattern = "^[a-zA-Z0-9가-힣]{1,16}";
+  public static final String NICKNAME_INVALID = "닉네임은 1~16자 한글, 영어, 숫자만 가능합니다.";
+
+  @Pattern(regexp = pattern, message = NICKNAME_INVALID)
+  @Column(name = "nickname", nullable = false, unique = true, length = MAX_NICKNAME_LENGTH)
+  private String nickname;
+
+  @Builder
+  private Nickname(String nickname) {
+    this.nickname = nickname;
+  }
+
+  public static Nickname from(String nickname) {
+    return Nickname.builder()
+        .nickname(nickname)
+        .build();
+  }
+}

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/entity/embedded/Nickname.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/entity/embedded/Nickname.java
@@ -16,10 +16,10 @@ import lombok.NoArgsConstructor;
 public class Nickname {
 
   public static final int MAX_NICKNAME_LENGTH = 45;
-  public static final String pattern = "^[a-zA-Z0-9가-힣]{1,16}";
+  public static final String PATTERN = "^[a-zA-Z0-9가-힣]{1,16}";
   public static final String NICKNAME_INVALID = "닉네임은 1~16자 한글, 영어, 숫자만 가능합니다.";
 
-  @Pattern(regexp = pattern, message = NICKNAME_INVALID)
+  @Pattern(regexp = PATTERN, message = NICKNAME_INVALID)
   @Column(name = "nickname", nullable = false, unique = true, length = MAX_NICKNAME_LENGTH)
   private String nickname;
 

--- a/src/main/java/com/dinosaur/foodbowl/global/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/config/security/SecurityConfiguration.java
@@ -26,7 +26,7 @@ public class SecurityConfiguration {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
         .authorizeRequests()
-        .requestMatchers("/docs/**", "/sign-up/*", "/log-in", "/thumbnail/**").permitAll()
+        .requestMatchers("/docs/**", "/sign-up/**", "/log-in", "/thumbnail/**").permitAll()
         .anyRequest().hasRole("회원")
         .and()
         .httpBasic().disable()

--- a/src/main/java/com/dinosaur/foodbowl/global/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/config/security/SecurityConfiguration.java
@@ -26,7 +26,7 @@ public class SecurityConfiguration {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
         .authorizeRequests()
-        .requestMatchers("/docs/**", "/sign-up", "/log-in", "/thumbnail/**").permitAll()
+        .requestMatchers("/docs/**", "/sign-up/*", "/log-in", "/thumbnail/**").permitAll()
         .anyRequest().hasRole("회원")
         .and()
         .httpBasic().disable()

--- a/src/main/java/com/dinosaur/foodbowl/global/error/ExceptionAdvice.java
+++ b/src/main/java/com/dinosaur/foodbowl/global/error/ExceptionAdvice.java
@@ -53,6 +53,8 @@ public class ExceptionAdvice {
 
   public static String getErrorMessage(String invalidValue, String errorField,
       String errorMessage) {
-    return String.format("[%s] %s: %s", invalidValue, errorField, errorMessage);
+    String[] layerErrorFields = errorField.split("\\.");
+    return String.format("[%s] %s: %s",
+        invalidValue, layerErrorFields[layerErrorFields.length - 1], errorMessage);
   }
 }

--- a/src/test/java/com/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
@@ -11,6 +11,7 @@ import static com.dinosaur.foodbowl.global.error.ErrorCode.PASSWORD_NOT_MATCH;
 import static com.dinosaur.foodbowl.global.error.ErrorCode.USER_NOT_FOUND;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -36,6 +37,7 @@ import com.dinosaur.foodbowl.IntegrationTest;
 import com.dinosaur.foodbowl.domain.auth.dto.AuthFieldError;
 import com.dinosaur.foodbowl.domain.auth.dto.request.LoginRequestDto;
 import com.dinosaur.foodbowl.domain.auth.dto.request.SignUpRequestDto;
+import com.dinosaur.foodbowl.domain.auth.dto.response.CheckResponseDto;
 import com.dinosaur.foodbowl.domain.auth.dto.response.SignUpResponseDto;
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.entity.Role.RoleType;
@@ -510,6 +512,38 @@ class AuthControllerTest extends IntegrationTest {
     private ResultActions callLogoutApi() throws Exception {
       return mockMvc.perform(post("/log-out")
               .cookie(new Cookie(ACCESS_TOKEN.getName(), userToken)))
+          .andDo(print());
+    }
+  }
+
+  @Nested
+  @DisplayName("닉네임 유효성 및 중복 검사")
+  class CheckNickname {
+
+    @Test
+    @DisplayName("닉네임 유효성 및 중복 검사에 성공한다.")
+    void should_success_when_checkNickname() throws Exception {
+      CheckResponseDto response = CheckResponseDto.of(true, "사용 가능한 닉네임입니다.");
+      doReturn(response).when(authService).checkNickname(anyString());
+
+      String nickname = "hello";
+      callCheckNicknameApi(nickname)
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.available").value(true))
+          .andExpect(jsonPath("$.message").value("사용 가능한 닉네임입니다."))
+          .andDo(document("nickname-check",
+              queryParameters(
+                  parameterWithName("nickname").description("유저가 입력한 닉네임")
+              ),
+              responseFields(
+                  fieldWithPath("available").description("true: 사용 가능 +\nfalse: 사용 불가능"),
+                  fieldWithPath("message").description("사용 불가능한 이유")
+              )));
+    }
+
+    private ResultActions callCheckNicknameApi(String nickname) throws Exception {
+      return mockMvc.perform(get("/sign-up/check/nickname")
+              .queryParam("nickname", nickname))
           .andDo(print());
     }
   }

--- a/src/test/java/com/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/auth/api/AuthControllerTest.java
@@ -2,7 +2,7 @@ package com.dinosaur.foodbowl.domain.auth.api;
 
 import static com.dinosaur.foodbowl.domain.user.entity.User.MAX_INTRODUCE_LENGTH;
 import static com.dinosaur.foodbowl.domain.user.entity.User.MAX_LOGIN_ID_LENGTH;
-import static com.dinosaur.foodbowl.domain.user.entity.User.MAX_NICKNAME_LENGTH;
+import static com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname.MAX_NICKNAME_LENGTH;
 import static com.dinosaur.foodbowl.global.config.security.jwt.JwtToken.ACCESS_TOKEN;
 import static com.dinosaur.foodbowl.global.config.security.jwt.JwtToken.REFRESH_TOKEN;
 import static com.dinosaur.foodbowl.global.error.ErrorCode.LOGIN_ID_DUPLICATE;
@@ -40,6 +40,7 @@ import com.dinosaur.foodbowl.domain.auth.dto.response.SignUpResponseDto;
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.entity.Role.RoleType;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
 import com.dinosaur.foodbowl.global.error.BusinessException;
 import com.dinosaur.foodbowl.global.error.ExceptionAdvice;
 import jakarta.servlet.http.Cookie;
@@ -198,7 +199,7 @@ class AuthControllerTest extends IntegrationTest {
           User.builder()
               .loginId(validLoginId)
               .password(validPassword)
-              .nickname(validNickname)
+              .nickname(Nickname.from(validNickname))
               .introduce(validIntroduce)
               .thumbnail(thumbnail)
               .build());
@@ -344,7 +345,7 @@ class AuthControllerTest extends IntegrationTest {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.message")
                 .value(ExceptionAdvice.getErrorMessage(invalidNickname, "nickname",
-                    AuthFieldError.NICKNAME_INVALID.getMessage())));
+                    Nickname.NICKNAME_INVALID)));
       }
 
       @Test

--- a/src/test/java/com/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
@@ -10,6 +10,7 @@ import com.dinosaur.foodbowl.domain.auth.dto.request.LoginRequestDto;
 import com.dinosaur.foodbowl.domain.auth.dto.request.SignUpRequestDto;
 import com.dinosaur.foodbowl.domain.auth.dto.response.SignUpResponseDto;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
 import com.dinosaur.foodbowl.global.error.BusinessException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +30,7 @@ class AuthServiceTest extends IntegrationTest {
       SignUpRequestDto request = SignUpRequestDto.builder()
           .loginId("TestLoginId")
           .password("TestPassword")
-          .nickname("TestNickname")
+          .nickname(Nickname.from("TestNickname"))
           .build();
 
       SignUpResponseDto response = authService.signUp(request);

--- a/src/test/java/com/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/auth/application/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.dinosaur.foodbowl.domain.auth.application;
 
+import static com.dinosaur.foodbowl.global.error.ErrorCode.NICKNAME_DUPLICATE;
 import static com.dinosaur.foodbowl.global.error.ErrorCode.PASSWORD_NOT_MATCH;
 import static com.dinosaur.foodbowl.global.error.ErrorCode.USER_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.dinosaur.foodbowl.IntegrationTest;
 import com.dinosaur.foodbowl.domain.auth.dto.request.LoginRequestDto;
 import com.dinosaur.foodbowl.domain.auth.dto.request.SignUpRequestDto;
+import com.dinosaur.foodbowl.domain.auth.dto.response.CheckResponseDto;
 import com.dinosaur.foodbowl.domain.auth.dto.response.SignUpResponseDto;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
@@ -16,6 +18,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class AuthServiceTest extends IntegrationTest {
 
@@ -122,6 +126,47 @@ class AuthServiceTest extends IntegrationTest {
       assertThatThrownBy(() -> authService.login(request))
           .isInstanceOf(BusinessException.class)
           .hasMessageContaining(PASSWORD_NOT_MATCH.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("닉네임 유효성 및 중복 검사")
+  class CheckNickname {
+
+    @Test
+    @DisplayName("닉네임 유효성 및 중복 검사에 통과한다.")
+    void should_success_when_checkNickname() {
+      String nickname = "hello";
+
+      CheckResponseDto checkResponseDto = authService.checkNickname(nickname);
+
+      assertThat(checkResponseDto.isAvailable()).isTrue();
+      assertThat(checkResponseDto.getMessage()).isEqualTo("사용 가능한 닉네임입니다.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "abcde###", "oh-my-zsh", "한글을_사랑합시다", "cant blank",
+        "01234567890123456", "         ", "012345678901234567890"})
+    @DisplayName("닉네임 유효성 검사에 실패한다.")
+    void should_fail_when_nicknameIsNotValid(String nickname) {
+      CheckResponseDto checkResponseDto = authService.checkNickname(nickname);
+
+      assertThat(checkResponseDto.isAvailable()).isFalse();
+      assertThat(checkResponseDto.getMessage()).isEqualTo(Nickname.NICKNAME_INVALID);
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 검사에 실패한다.")
+    void should_fail_when_nicknameIsDuplicate() {
+      String nickname = "hello";
+      userTestHelper.builder()
+          .nickname(nickname)
+          .build();
+
+      CheckResponseDto checkResponseDto = authService.checkNickname(nickname);
+
+      assertThat(checkResponseDto.isAvailable()).isFalse();
+      assertThat(checkResponseDto.getMessage()).isEqualTo(NICKNAME_DUPLICATE.getMessage());
     }
   }
 }

--- a/src/test/java/com/dinosaur/foodbowl/domain/follow/dao/FollowRepositoryTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/follow/dao/FollowRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.dinosaur.foodbowl.IntegrationTest;
 import com.dinosaur.foodbowl.domain.follow.entity.Follow;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,7 @@ class FollowRepositoryTest extends IntegrationTest {
       User user = User.builder()
           .loginId(loginId)
           .password(password)
-          .nickname(nickname)
+          .nickname(Nickname.from(nickname))
           .introduce(introduce)
           .build();
       return userRepository.save(user);

--- a/src/test/java/com/dinosaur/foodbowl/domain/user/UserTestHelper.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/user/UserTestHelper.java
@@ -1,13 +1,13 @@
 package com.dinosaur.foodbowl.domain.user;
 
 import static com.dinosaur.foodbowl.domain.user.entity.User.MAX_LOGIN_ID_LENGTH;
-import static com.dinosaur.foodbowl.domain.user.entity.User.MAX_NICKNAME_LENGTH;
 import static com.dinosaur.foodbowl.domain.user.entity.User.MAX_PASSWORD_LENGTH;
 
 import com.dinosaur.foodbowl.domain.thumbnail.ThumbnailTestHelper;
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.dao.UserRepository;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -73,7 +73,8 @@ public class UserTestHelper {
           .thumbnail(thumbnail)
           .loginId(loginId != null ? loginId : getRandomUUIDLengthWith(MAX_LOGIN_ID_LENGTH))
           .password(password != null ? password : getRandomUUIDLengthWith(MAX_PASSWORD_LENGTH))
-          .nickname(nickname != null ? nickname : getRandomUUIDLengthWith(MAX_NICKNAME_LENGTH))
+          .nickname(nickname != null ? Nickname.from(nickname)
+              : Nickname.from(getRandomUUIDLengthWith(Nickname.MAX_NICKNAME_LENGTH)))
           .introduce(introduce)
           .build());
     }

--- a/src/test/java/com/dinosaur/foodbowl/domain/user/application/GetProfileServiceTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/user/application/GetProfileServiceTest.java
@@ -41,7 +41,7 @@ class GetProfileServiceTest extends IntegrationTest {
       ProfileResponseDto result = getProfileService.getProfile(me.getId());
 
       assertThat(result.getUserId()).isEqualTo(me.getId());
-      assertThat(result.getNickname()).isEqualTo(me.getNickname());
+      assertThat(result.getNickname()).isEqualTo(me.getNickname().getNickname());
       assertThat(result.getIntroduce()).isEqualTo(me.getIntroduce());
       assertThat(result.getThumbnailURL()).isEqualTo(me.getThumbnailURL().orElseThrow());
       assertThat(result.getFollowerCount()).isEqualTo(1);
@@ -67,7 +67,7 @@ class GetProfileServiceTest extends IntegrationTest {
       ProfileResponseDto result = getProfileService.getProfile(me.getId());
 
       assertThat(result.getUserId()).isEqualTo(me.getId());
-      assertThat(result.getNickname()).isEqualTo(me.getNickname());
+      assertThat(result.getNickname()).isEqualTo(me.getNickname().getNickname());
       assertThat(result.getIntroduce()).isEqualTo(me.getIntroduce());
       assertThat(result.getThumbnailURL()).isEqualTo(me.getThumbnailURL().orElseThrow());
       assertThat(result.getPostCount()).isEqualTo(myPostCount);

--- a/src/test/java/com/dinosaur/foodbowl/domain/user/dao/UserRepositoryTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/user/dao/UserRepositoryTest.java
@@ -9,6 +9,7 @@ import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.UserTestHelper.UserBuilder;
 import com.dinosaur.foodbowl.domain.user.entity.Role.RoleType;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.domain.user.entity.embedded.Nickname;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,7 +35,7 @@ class UserRepositoryTest extends IntegrationTest {
     @DisplayName("유니크 컬럼에 중복이 발생하면 예외가 발생한다.")
     void should_throwException_when_uniqueColumnIsDuplicate() {
       assertThatThrownBy(() -> userBuilder.loginId(user.getLoginId()).build());
-      assertThatThrownBy(() -> userBuilder.nickname(user.getNickname()).build());
+      assertThatThrownBy(() -> userBuilder.nickname((user.getNickname()).getNickname()).build());
     }
 
     @Test
@@ -72,7 +73,7 @@ class UserRepositoryTest extends IntegrationTest {
     @Test
     @DisplayName("닉네임이 존재하면 true 반환한다.")
     void should_returnTrue_when_nicknameExist() {
-      String nickname = user.getNickname();
+      Nickname nickname = Nickname.from(user.getNickname().getNickname());
 
       boolean result = userRepository.existsByNickname(nickname);
 
@@ -82,7 +83,7 @@ class UserRepositoryTest extends IntegrationTest {
     @Test
     @DisplayName("닉네임이 존재하지 않으면 false 반환한다.")
     void should_returnFalse_when_nicknameNotExist() {
-      String nickname = "not-exist-nickname";
+      Nickname nickname = Nickname.from("not-exist-nickname");
 
       boolean result = userRepository.existsByNickname(nickname);
 


### PR DESCRIPTION
## 🔥 Related Issue

close: #79

## 📝 Description

- 닉네임 유효성 및 중복 검사 로직 구현

## 🌟 Review

**Request Dto 역직렬화**

```java
public class RequestDto {
  private String nickname;
  private Nickname nickname2;
}

public class Nickname {
  private String nickname;

  private Nickname(String nickname) {
    this.nickname = nickname;
  }
}
```

```json
{
  "nickname": "hi",
  "nickname2": "hello"
}
```

내부 필드가 새로운 계층을 가질 때 필드가 1개만 존재하고, 존재하는 필드에 대한 생성자가 열려있으면,
해당 객체 필드명으로 온 데이터는 생성자를 통해 생성된다.

`ArgumentResolver`에 의해 해당 타입으로 변환할 수 없으면 예외가 발생한다!