### PR TITLE
Feature/#82 유저, 게시글, 댓글 신고 관련 테이블을 설계한다.

### DIFF
--- a/src/main/java/com/dinosaur/foodbowl/domain/blame/dao/BlameRepository.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/blame/dao/BlameRepository.java
@@ -1,0 +1,8 @@
+package com.dinosaur.foodbowl.domain.blame.dao;
+
+import com.dinosaur.foodbowl.domain.blame.entity.Blame;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlameRepository extends JpaRepository<Blame, Long> {
+
+}

--- a/src/main/java/com/dinosaur/foodbowl/domain/blame/entity/Blame.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/blame/entity/Blame.java
@@ -1,0 +1,45 @@
+package com.dinosaur.foodbowl.domain.blame.entity;
+
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "blame")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+public class Blame extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", nullable = false, updatable = false)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false, updatable = false)
+  private User user;
+
+  @Column(name = "target_id", nullable = false, updatable = false)
+  private Long targetId;
+
+  @Enumerated(value = EnumType.ORDINAL)
+  @Column(name = "target_type", nullable = false, updatable = false)
+  private TargetType targetType;
+
+  public enum TargetType {
+    USER, POST, COMMENT;
+  }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #82

## 📝 작업 요약

신고 테이블에 대한 엔티티와 레포지토리를 구현했습니다.

## 🔎 작업 상세 설명

각각 신고 테이블을 두기보다는 하나의 신고 테이블로 관리하기로 하였습니다.
`target_id`는 유저, 게시글, 댓글의 PK를 저장하고,
`target_type`은 1(유저), 2(게시글), 3(댓글)에 해당하는 정보를 저장합니다.

`target_type`은 별도의 DB 저장 없이 **Enum**으로 관리하도록 하였습니다.

## 🌟 리뷰 요구 사항

> 소요 시간 : 3분