### PR TITLE
Feature/#29 댓글 불러오는 기능을 구현한다.

### DIFF
--- a/src/docs/asciidoc/comment/comment.adoc
+++ b/src/docs/asciidoc/comment/comment.adoc
@@ -90,3 +90,29 @@ include::{snippets}/comment-delete/path-parameters.adoc[]
 ==== Response
 
 include::{snippets}/comment-delete/http-response.adoc[]
+
+== *게시글 댓글 목록 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/comment-list/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/comment-list/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/comment-list/path-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/comment-list/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/comment-list/response-fields.adoc[]

--- a/src/main/java/com/dinosaur/foodbowl/domain/blame/entity/Blame.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/blame/entity/Blame.java
@@ -14,13 +14,16 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @Table(name = "blame")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(of = {"id"}, callSuper = false)
+@EqualsAndHashCode(of = {"user", "targetId", "targetType"}, callSuper = false)
 public class Blame extends BaseEntity {
 
   @Id
@@ -41,5 +44,12 @@ public class Blame extends BaseEntity {
 
   public enum TargetType {
     USER, POST, COMMENT;
+  }
+
+  @Builder
+  private Blame(User user, Long targetId, TargetType targetType) {
+    this.user = user;
+    this.targetId = targetId;
+    this.targetType = targetType;
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/comment/api/CommentController.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/comment/api/CommentController.java
@@ -2,6 +2,7 @@ package com.dinosaur.foodbowl.domain.comment.api;
 
 import com.dinosaur.foodbowl.domain.comment.application.CommentService;
 import com.dinosaur.foodbowl.domain.comment.dto.request.CommentWriteRequestDto;
+import com.dinosaur.foodbowl.domain.comment.dto.response.CommentResponseDto;
 import com.dinosaur.foodbowl.domain.comment.entity.Comment;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.global.util.resolver.LoginUser;
@@ -9,11 +10,13 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -57,5 +60,12 @@ public class CommentController {
     commentService.deleteComment(user, commentId);
 
     return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/posts/{id}")
+  public ResponseEntity<List<CommentResponseDto>> getComments(@PathVariable("id") Long postId) {
+    List<CommentResponseDto> comments = commentService.getComments(postId);
+
+    return ResponseEntity.ok(comments);
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/comment/application/CommentService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/comment/application/CommentService.java
@@ -4,11 +4,14 @@ import static com.dinosaur.foodbowl.global.error.ErrorCode.COMMENT_NOT_WRITER;
 
 import com.dinosaur.foodbowl.domain.comment.dao.CommentRepository;
 import com.dinosaur.foodbowl.domain.comment.dto.request.CommentWriteRequestDto;
+import com.dinosaur.foodbowl.domain.comment.dto.response.CommentResponseDto;
 import com.dinosaur.foodbowl.domain.comment.entity.Comment;
 import com.dinosaur.foodbowl.domain.post.application.PostFindService;
 import com.dinosaur.foodbowl.domain.post.entity.Post;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.global.error.BusinessException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,5 +54,14 @@ public class CommentService {
     }
 
     commentRepository.delete(comment);
+  }
+
+  public List<CommentResponseDto> getComments(final long postId) {
+    Post post = postFindService.findById(postId);
+    List<Comment> comments = commentRepository.findUnrestrictedComments(post);
+
+    return comments.stream()
+        .map(CommentResponseDto::from)
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/comment/dao/CommentRepository.java
@@ -1,8 +1,18 @@
 package com.dinosaur.foodbowl.domain.comment.dao;
 
 import com.dinosaur.foodbowl.domain.comment.entity.Comment;
+import com.dinosaur.foodbowl.domain.post.entity.Post;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+  @Query("select c from Comment c"
+      + " left join fetch c.blames"
+      + " join fetch c.user"
+      + " left join fetch c.user.thumbnail"
+      + " where c.post = :post and size(c.blames) < 5 order by c.createdAt")
+  List<Comment> findUnrestrictedComments(@Param("post") Post post);
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/comment/dto/response/CommentResponseDto.java
@@ -1,0 +1,31 @@
+package com.dinosaur.foodbowl.domain.comment.dto.response;
+
+import com.dinosaur.foodbowl.domain.comment.entity.Comment;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentResponseDto {
+
+  private String nickname;
+  private String userThumbnailPath;
+  private String message;
+  @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+  private LocalDateTime createdAt;
+
+  public static CommentResponseDto from(Comment comment) {
+    return CommentResponseDto.builder()
+        .nickname(comment.getUser().getNickname().getNickname())
+        .userThumbnailPath(comment.getUser().getThumbnailURL().orElseGet(() -> null))
+        .message(comment.getMessage())
+        .createdAt(comment.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/dinosaur/foodbowl/domain/comment/entity/Comment.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/comment/entity/Comment.java
@@ -1,8 +1,11 @@
 package com.dinosaur.foodbowl.domain.comment.entity;
 
+import com.dinosaur.foodbowl.domain.blame.entity.Blame;
+import com.dinosaur.foodbowl.domain.blame.entity.Blame.TargetType;
 import com.dinosaur.foodbowl.domain.post.entity.Post;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -12,8 +15,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -52,6 +58,10 @@ public class Comment extends BaseEntity {
   @Column(name = "message", nullable = false, length = MAX_MESSAGE_LENGTH)
   private String message;
 
+  @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+  @JoinColumn(name = "target_id", updatable = false)
+  private List<Blame> blames = new ArrayList<>();
+
   @LastModifiedDate
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
@@ -66,5 +76,17 @@ public class Comment extends BaseEntity {
 
   public void updateMessage(String message) {
     this.message = message;
+  }
+
+  public void report(User user) {
+    Blame blame = Blame.builder()
+        .user(user)
+        .targetId(this.id)
+        .targetType(TargetType.COMMENT)
+        .build();
+
+    if (!blames.contains(blame)) {
+      blames.add(blame);
+    }
   }
 }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -9,6 +9,7 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+        default_batch_fetch_size: 50
     defer-datasource-initialization: true
 
   servlet:

--- a/src/test/java/com/dinosaur/foodbowl/IntegrationTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/IntegrationTest.java
@@ -13,6 +13,8 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 
 import com.dinosaur.foodbowl.domain.auth.application.AuthService;
 import com.dinosaur.foodbowl.domain.auth.application.TokenService;
+import com.dinosaur.foodbowl.domain.blame.BlameTestHelper;
+import com.dinosaur.foodbowl.domain.blame.dao.BlameRepository;
 import com.dinosaur.foodbowl.domain.category.dao.CategoryRepository;
 import com.dinosaur.foodbowl.domain.comment.CommentTestHelper;
 import com.dinosaur.foodbowl.domain.comment.application.CommentFindService;
@@ -96,6 +98,9 @@ public class IntegrationTest {
   @SpyBean
   protected CommentRepository commentRepository;
 
+  @SpyBean
+  protected BlameRepository blameRepository;
+
   /******* Service *******/
   @SpyBean
   protected GetProfileService getProfileService;
@@ -139,6 +144,9 @@ public class IntegrationTest {
 
   @Autowired
   protected CommentTestHelper commentTestHelper;
+
+  @Autowired
+  protected BlameTestHelper blameTestHelper;
 
   /******* Util *******/
   @SpyBean

--- a/src/test/java/com/dinosaur/foodbowl/domain/blame/BlameTestHelper.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/blame/BlameTestHelper.java
@@ -1,0 +1,53 @@
+package com.dinosaur.foodbowl.domain.blame;
+
+import com.dinosaur.foodbowl.domain.blame.dao.BlameRepository;
+import com.dinosaur.foodbowl.domain.blame.entity.Blame;
+import com.dinosaur.foodbowl.domain.blame.entity.Blame.TargetType;
+import com.dinosaur.foodbowl.domain.user.UserTestHelper;
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BlameTestHelper {
+
+  @Autowired
+  private BlameRepository blameRepository;
+
+  @Autowired
+  private UserTestHelper userTestHelper;
+
+  public BlameBuilder builder() {
+    return new BlameBuilder();
+  }
+
+  public final class BlameBuilder {
+
+    private User user;
+    private Long targetId;
+    private TargetType targetType;
+
+    public BlameBuilder user(User user) {
+      this.user = user;
+      return this;
+    }
+
+    public BlameBuilder targetId(Long targetId) {
+      this.targetId = targetId;
+      return this;
+    }
+
+    public BlameBuilder targetType(TargetType targetType) {
+      this.targetType = targetType;
+      return this;
+    }
+
+    public Blame build() {
+      return blameRepository.save(Blame.builder()
+          .user(user != null ? user : userTestHelper.builder().build())
+          .targetId(targetId != null ? targetId : 1L)
+          .targetType(targetType != null ? targetType : TargetType.USER)
+          .build());
+    }
+  }
+}

--- a/src/test/java/com/dinosaur/foodbowl/domain/comment/api/CommentControllerTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/comment/api/CommentControllerTest.java
@@ -13,21 +13,28 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dinosaur.foodbowl.IntegrationTest;
 import com.dinosaur.foodbowl.domain.comment.dto.request.CommentWriteRequestDto;
+import com.dinosaur.foodbowl.domain.comment.dto.response.CommentResponseDto;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import jakarta.servlet.http.Cookie;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -207,6 +214,75 @@ class CommentControllerTest extends IntegrationTest {
 
     private ResultActions callDeleteCommentApi(String id) throws Exception {
       return mockMvc.perform(delete("/comments/{id}", id)
+              .cookie(new Cookie(ACCESS_TOKEN.getName(), "token")))
+          .andDo(print());
+    }
+  }
+
+  @Nested
+  @DisplayName("제한되지 않은 댓글 시간순으로 찾기")
+  class GetComments {
+
+    @Test
+    @DisplayName("댓글 목록 가져오기 성공")
+    void should_success_when_getComments() throws Exception {
+      mockingAuth();
+
+      LocalDateTime now = LocalDateTime.now();
+
+      CommentResponseDto response1 = CommentResponseDto.builder()
+          .nickname("nickname1")
+          .userThumbnailPath("path1")
+          .message("message1")
+          .createdAt(now)
+          .build();
+      CommentResponseDto response2 = CommentResponseDto.builder()
+          .nickname("nickname2")
+          .userThumbnailPath("path2")
+          .message("message2")
+          .createdAt(now)
+          .build();
+
+      doReturn(List.of(response1, response2)).when(commentService).getComments(anyLong());
+
+      callGetCommentsApi("1")
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$[0].nickname").value(response1.getNickname()))
+          .andExpect(jsonPath("$[0].userThumbnailPath").value(response1.getUserThumbnailPath()))
+          .andExpect(jsonPath("$[0].message").value(response1.getMessage()))
+          .andExpect(jsonPath("$[0].createdAt")
+              .value(now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))))
+          .andExpect(jsonPath("$[1].nickname").value(response2.getNickname()))
+          .andExpect(jsonPath("$[1].userThumbnailPath").value(response2.getUserThumbnailPath()))
+          .andExpect(jsonPath("$[1].message").value(response2.getMessage()))
+          .andExpect(jsonPath("$[1].createdAt")
+              .value(now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))))
+          .andDo(document("comment-list",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getName()).description("사용자 인증에 필요한 access token")
+              ),
+              pathParameters(
+                  parameterWithName("id").description("댓글 조회하고자 하는 게시글 ID")
+              ),
+              responseFields(
+                  fieldWithPath("[].nickname").description("유저 닉네임"),
+                  fieldWithPath("[].userThumbnailPath").description("유저 썸네일 +\n존재하지 않으면 null"),
+                  fieldWithPath("[].message").description("유저가 작성한 댓글 내용"),
+                  fieldWithPath("[].createdAt").description("댓글 작성 시간 +\n(yyyy-MM-dd'T'HH:mm:ss")
+              )));
+    }
+
+    @Test
+    @DisplayName("ID로 변환할 수 없으면 예외가 발생한다.")
+    void should_throwException_when_IdNotConvert() throws Exception {
+      mockingAuth();
+
+      callGetCommentsApi("hello")
+          .andExpect(status().isBadRequest());
+    }
+
+    private ResultActions callGetCommentsApi(String id) throws Exception {
+      return mockMvc.perform(get("/comments/posts/{id}", id)
               .cookie(new Cookie(ACCESS_TOKEN.getName(), "token")))
           .andDo(print());
     }

--- a/src/test/java/com/dinosaur/foodbowl/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/comment/application/CommentServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.dinosaur.foodbowl.IntegrationTest;
 import com.dinosaur.foodbowl.domain.comment.dto.request.CommentWriteRequestDto;
+import com.dinosaur.foodbowl.domain.comment.dto.response.CommentResponseDto;
 import com.dinosaur.foodbowl.domain.comment.entity.Comment;
 import com.dinosaur.foodbowl.domain.post.entity.Post;
 import com.dinosaur.foodbowl.domain.user.entity.User;
@@ -107,6 +108,28 @@ class CommentServiceTest extends IntegrationTest {
       assertThatThrownBy(() -> commentService.deleteComment(user, comment.getId()))
           .isInstanceOf(BusinessException.class)
           .hasMessageContaining(COMMENT_NOT_WRITER.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("제한되지 않은 댓글 시간순으로 찾기")
+  class GetComments {
+
+    @Test
+    @DisplayName("응답을 위한 댓글 목록을 반환한다.")
+    void should_returnComments_when_getComments() {
+      User user = userTestHelper.builder().build();
+      Post post = postTestHelper.builder().build();
+      Comment comment = commentTestHelper.builder().user(user).post(post).message("test").build();
+
+      List<CommentResponseDto> comments = commentService.getComments(post.getId());
+
+      assertThat(comments.size()).isEqualTo(1);
+      assertThat(comments.get(0).getNickname()).isEqualTo(user.getNickname().getNickname());
+      assertThat(comments.get(0).getUserThumbnailPath()).isEqualTo(
+          user.getThumbnailURL().orElseGet(() -> null));
+      assertThat(comments.get(0).getMessage()).isEqualTo(comment.getMessage());
+      assertThat(comments.get(0).getCreatedAt()).isEqualTo(comment.getCreatedAt());
     }
   }
 }

--- a/src/test/java/com/dinosaur/foodbowl/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/comment/application/CommentServiceTest.java
@@ -120,16 +120,22 @@ class CommentServiceTest extends IntegrationTest {
     void should_returnComments_when_getComments() {
       User user = userTestHelper.builder().build();
       Post post = postTestHelper.builder().build();
-      Comment comment = commentTestHelper.builder().user(user).post(post).message("test").build();
+      Comment comment1 = commentTestHelper.builder().user(user).post(post).message("test1").build();
+      Comment comment2 = commentTestHelper.builder().user(user).post(post).message("test2").build();
 
       List<CommentResponseDto> comments = commentService.getComments(post.getId());
 
-      assertThat(comments.size()).isEqualTo(1);
+      assertThat(comments.size()).isEqualTo(2);
       assertThat(comments.get(0).getNickname()).isEqualTo(user.getNickname().getNickname());
       assertThat(comments.get(0).getUserThumbnailPath()).isEqualTo(
           user.getThumbnailURL().orElseGet(() -> null));
-      assertThat(comments.get(0).getMessage()).isEqualTo(comment.getMessage());
-      assertThat(comments.get(0).getCreatedAt()).isEqualTo(comment.getCreatedAt());
+      assertThat(comments.get(0).getMessage()).isEqualTo(comment1.getMessage());
+      assertThat(comments.get(0).getCreatedAt()).isEqualTo(comment1.getCreatedAt());
+      assertThat(comments.get(1).getNickname()).isEqualTo(user.getNickname().getNickname());
+      assertThat(comments.get(1).getUserThumbnailPath()).isEqualTo(
+          user.getThumbnailURL().orElseGet(() -> null));
+      assertThat(comments.get(1).getMessage()).isEqualTo(comment2.getMessage());
+      assertThat(comments.get(1).getCreatedAt()).isEqualTo(comment2.getCreatedAt());
     }
   }
 }

--- a/src/test/java/com/dinosaur/foodbowl/domain/comment/dao/CommentRepositoryTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/comment/dao/CommentRepositoryTest.java
@@ -1,0 +1,87 @@
+package com.dinosaur.foodbowl.domain.comment.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dinosaur.foodbowl.IntegrationTest;
+import com.dinosaur.foodbowl.domain.blame.entity.Blame;
+import com.dinosaur.foodbowl.domain.comment.entity.Comment;
+import com.dinosaur.foodbowl.domain.post.entity.Post;
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CommentRepositoryTest extends IntegrationTest {
+
+  @Nested
+  @DisplayName("제한되지 않은 댓글 시간순으로 찾기")
+  class FindUnrestrictedComments {
+
+    @Test
+    @DisplayName("게시글 댓글을 순차적으로 가져온다.")
+    void should_success_when_findUnrestrictedComments() {
+      Post oldPost = postTestHelper.builder().build();
+      Post newPost = postTestHelper.builder().build();
+      Comment oldPostComment = commentTestHelper.builder().post(oldPost).message("test1")
+          .build();
+      Comment newPostComment = commentTestHelper.builder().post(newPost).message("test2").build();
+      Comment oldPostComment2 = commentTestHelper.builder().post(oldPost).message("test3").build();
+
+      List<Comment> comments = commentRepository.findUnrestrictedComments(oldPost);
+
+      assertThat(comments.size()).isEqualTo(2);
+      assertThat(comments.get(0).getMessage()).isEqualTo(oldPostComment.getMessage());
+      assertThat(comments.get(1).getMessage()).isEqualTo(oldPostComment2.getMessage());
+    }
+
+    @Test
+    @DisplayName("신고가 5회 이상 존재하는 댓글은 가져오지 않는다.")
+    void should_notBring_when_commentsMoreThanFiveReports() {
+      Post post = postTestHelper.builder().build();
+      User user = userTestHelper.builder().build();
+      Comment unrestrictedComment = commentTestHelper.builder().post(post).message("test1").build();
+      Comment restrictedComment = commentTestHelper.builder().post(post).message("test2").build();
+
+      unrestrictedComment.report(user);
+      for (int i = 0; i < 5; i++) {
+        user = userTestHelper.builder().build();
+        restrictedComment.report(user);
+      }
+
+      em.flush();
+      em.clear();
+
+      List<Comment> comments = commentRepository.findUnrestrictedComments(post);
+
+      assertThat(comments.size()).isEqualTo(1);
+      assertThat(comments.get(0).getMessage()).isEqualTo(unrestrictedComment.getMessage());
+      assertThat(comments.get(0).getBlames().size()).isEqualTo(1);
+    }
+  }
+
+  @Nested
+  @DisplayName("댓글 삭제")
+  class DeleteComment {
+
+    @Test
+    @DisplayName("댓글을 삭제하면 연관된 신고도 함께 삭제된다.")
+    void should_deleteBlames_when_deleteComment() {
+      User user = userTestHelper.builder().build();
+      Comment comment = commentTestHelper.builder().build();
+
+      comment.report(user);
+
+      em.flush();
+      em.clear();
+
+      commentRepository.delete(comment);
+
+      List<Comment> comments = commentRepository.findAll();
+      List<Blame> blames = blameRepository.findAll();
+
+      assertThat(comments.size()).isEqualTo(0);
+      assertThat(blames.size()).isEqualTo(0);
+    }
+  }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #29

## 📝 작업 요약

게시글의 신고로 제한되지 않은 댓글 목록을 순차적으로 조회하는 기능을 구현한다.

## 🔎 작업 상세 설명

- JPQL의 `fetch join`을 활용하여 불필요한 쿼리문이 수행되지 않도록 하였습니다.
- `@JsonFormat`을 통해 유효한 시간의 정보를 전달하였습니다.
- cascade, 연관관계 편의 메서드를 적극적으로 활용하였습니다.
- 일대다 연관관계에서 `update` 쿼리가 날라가지 않도록 설정하였습니다.
- `batch_size`를 이용해 `1+N` 쿼리 문제를 해결하고자 하였습니다.

## 🌟 리뷰 요구 사항

> 10분
> 작성 상세 설명에 나와있는 내용을 집중적으로 리뷰해주시면 감사합니다!