### PR TITLE
Feature/#24 작성한 게시글 썸네일 목록

### DIFF
--- a/src/docs/asciidoc/foodbowl.adoc
+++ b/src/docs/asciidoc/foodbowl.adoc
@@ -17,6 +17,10 @@ link:user/user.html[API 문서 보기]
 
 link:follow/follow.html[API 문서 보기]
 
+== *POST API*
+
+link:post/post.html[API 문서 보기]
+
 == *COMMENT API*
 
 link:comment/comment.html[API 문서 보기]

--- a/src/docs/asciidoc/post/post.adoc
+++ b/src/docs/asciidoc/post/post.adoc
@@ -1,0 +1,48 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= POST API 문서
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 1
+:sectlinks:
+
+== API 목록
+
+link:../foodbowl.html[API 목록으로 돌아가기]
+
+== *게시글 썸네일 목록 조회*
+
+NOTE: 모든 목록을 조회하는 것이 아닌 페이징을 통한 조회입니다.
+
+=== 요청
+
+==== Request
+
+include::{snippets}/post-thumbnail-list/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/post-thumbnail-list/request-cookies.adoc[]
+
+==== Path Parameters
+
+include::{snippets}/post-thumbnail-list/path-parameters.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/post-thumbnail-list/query-parameters.adoc[]
+
+NOTE: page, size를 지정하지 않아도 디폴트 값으로 처리됩니다.
+
+=== 응답
+
+==== Response
+
+include::{snippets}/post-thumbnail-list/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/post-thumbnail-list/response-fields.adoc[]

--- a/src/main/java/com/dinosaur/foodbowl/domain/post/api/PostController.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/post/api/PostController.java
@@ -1,0 +1,30 @@
+package com.dinosaur.foodbowl.domain.post.api;
+
+import com.dinosaur.foodbowl.domain.post.application.PostService;
+import com.dinosaur.foodbowl.domain.post.dto.response.PostThumbnailResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+public class PostController {
+
+  private final PostService postService;
+
+  @GetMapping("/users/{id}/thumbnails")
+  public ResponseEntity<List<PostThumbnailResponseDto>> getThumbnails(
+      @PathVariable("id") Long userId,
+      @PageableDefault(size = 18, sort = "createdAt") Pageable pageable) {
+    List<PostThumbnailResponseDto> response = postService.getThumbnails(userId, pageable);
+
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/dinosaur/foodbowl/domain/post/application/PostService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/post/application/PostService.java
@@ -1,0 +1,32 @@
+package com.dinosaur.foodbowl.domain.post.application;
+
+import com.dinosaur.foodbowl.domain.post.dao.PostRepository;
+import com.dinosaur.foodbowl.domain.post.dto.response.PostThumbnailResponseDto;
+import com.dinosaur.foodbowl.domain.post.entity.Post;
+import com.dinosaur.foodbowl.domain.user.application.UserFindService;
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+  private final PostRepository postRepository;
+  private final UserFindService userFindService;
+
+  public List<PostThumbnailResponseDto> getThumbnails(Long userId, Pageable pageable) {
+    User user = userFindService.findById(userId);
+
+    List<Post> posts = postRepository.findThumbnailsByUser(user, pageable);
+
+    return posts.stream()
+        .map(PostThumbnailResponseDto::from)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/dinosaur/foodbowl/domain/post/dao/PostRepository.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/post/dao/PostRepository.java
@@ -1,8 +1,15 @@
 package com.dinosaur.foodbowl.domain.post.dao;
 
 import com.dinosaur.foodbowl.domain.post.entity.Post;
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
+  @Query("select p from Post p left join fetch p.thumbnail where p.user = :user")
+  List<Post> findThumbnailsByUser(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/post/dto/response/PostThumbnailResponseDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/post/dto/response/PostThumbnailResponseDto.java
@@ -1,0 +1,27 @@
+package com.dinosaur.foodbowl.domain.post.dto.response;
+
+import com.dinosaur.foodbowl.domain.post.entity.Post;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostThumbnailResponseDto {
+
+  private String thumbnailPath;
+  @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+  private LocalDateTime createdAt;
+
+  public static PostThumbnailResponseDto from(Post post) {
+    return PostThumbnailResponseDto.builder()
+        .thumbnailPath(post.getThumbnail().getPath())
+        .createdAt(post.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/dinosaur/foodbowl/domain/post/entity/Post.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/post/entity/Post.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
 @Entity
 @Table(name = "post")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,7 +31,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class Post extends BaseEntity {
 
-  @Getter
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id", updatable = false, nullable = false)

--- a/src/test/java/com/dinosaur/foodbowl/IntegrationTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/IntegrationTest.java
@@ -22,6 +22,8 @@ import com.dinosaur.foodbowl.domain.follow.application.FollowService;
 import com.dinosaur.foodbowl.domain.follow.dao.FollowRepository;
 import com.dinosaur.foodbowl.domain.post.PostTestHelper;
 import com.dinosaur.foodbowl.domain.post.application.PostFindService;
+import com.dinosaur.foodbowl.domain.post.application.PostService;
+import com.dinosaur.foodbowl.domain.post.dao.PostRepository;
 import com.dinosaur.foodbowl.domain.thumbnail.ThumbnailTestHelper;
 import com.dinosaur.foodbowl.domain.thumbnail.dao.ThumbnailRepository;
 import com.dinosaur.foodbowl.domain.thumbnail.file.ThumbnailFileUtil;
@@ -76,13 +78,10 @@ public class IntegrationTest {
 
   /******* Repository *******/
   @SpyBean
-  protected RoleRepository roleRepository;
-
-  @SpyBean
   protected UserRepository userRepository;
 
   @SpyBean
-  protected ThumbnailRepository thumbnailRepository;
+  protected RoleRepository roleRepository;
 
   @SpyBean
   protected UserRoleRepository userRoleRepository;
@@ -91,15 +90,18 @@ public class IntegrationTest {
   protected FollowRepository followRepository;
 
   @SpyBean
+  protected ThumbnailRepository thumbnailRepository;
+
+  @SpyBean
+  protected PostRepository postRepository;
+
+  @SpyBean
   protected CategoryRepository categoryRepository;
 
   @SpyBean
   protected CommentRepository commentRepository;
 
   /******* Service *******/
-  @SpyBean
-  protected GetProfileService getProfileService;
-
   @SpyBean
   protected AuthService authService;
 
@@ -110,6 +112,9 @@ public class IntegrationTest {
   protected UserFindService userFindService;
 
   @SpyBean
+  protected GetProfileService getProfileService;
+
+  @SpyBean
   protected DeleteAccountService deleteAccountService;
 
   @SpyBean
@@ -117,6 +122,9 @@ public class IntegrationTest {
 
   @SpyBean
   protected FollowService followService;
+
+  @SpyBean
+  protected PostService postService;
 
   @SpyBean
   protected PostFindService postFindService;

--- a/src/test/java/com/dinosaur/foodbowl/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/post/api/PostControllerTest.java
@@ -1,0 +1,101 @@
+package com.dinosaur.foodbowl.domain.post.api;
+
+import static com.dinosaur.foodbowl.global.config.security.jwt.JwtToken.ACCESS_TOKEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dinosaur.foodbowl.IntegrationTest;
+import com.dinosaur.foodbowl.domain.post.dto.response.PostThumbnailResponseDto;
+import jakarta.servlet.http.Cookie;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.web.servlet.ResultActions;
+
+class PostControllerTest extends IntegrationTest {
+
+  @Nested
+  @DisplayName("유저 게시글 썸네일 목록 불러오기")
+  class GetThumbnails {
+
+    @Test
+    @DisplayName("썸네일 목록 불러오기 성공")
+    void should_success_when_getThumbnails() throws Exception {
+      mockingAuth();
+
+      LocalDateTime now = LocalDateTime.now();
+
+      PostThumbnailResponseDto response1 = PostThumbnailResponseDto.builder()
+          .thumbnailPath("path1")
+          .createdAt(now)
+          .build();
+      PostThumbnailResponseDto response2 = PostThumbnailResponseDto.builder()
+          .thumbnailPath("path2")
+          .createdAt(now)
+          .build();
+
+      doReturn(List.of(response1, response2)).when(postService)
+          .getThumbnails(anyLong(), any(Pageable.class));
+
+      callGetThumbnailsApi("1")
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("[0].thumbnailPath").value(response1.getThumbnailPath()))
+          .andExpect(jsonPath("[0].createdAt")
+              .value(now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))))
+          .andExpect(jsonPath("[1].thumbnailPath").value(response2.getThumbnailPath()))
+          .andExpect(jsonPath("[1].createdAt")
+              .value(now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))))
+          .andDo(document("post-thumbnail-list",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getName()).description("사용자 인증에 필요한 access token")
+              ),
+              pathParameters(
+                  parameterWithName("id").description("게시글 썸네일 목록을 불러오고 싶은 유저 ID")
+              ),
+              queryParameters(
+                  parameterWithName("page").optional()
+                      .description("불러오고 싶은 썸네일 목록 페이지 +\n(default: 0)"),
+                  parameterWithName("size").optional()
+                      .description("불러오고 싶은 썸네일 목록 크기 +\n(default: 18)")
+              ),
+              responseFields(
+                  fieldWithPath("[].thumbnailPath").description("게시글 썸네일 URI"),
+                  fieldWithPath("[].createdAt").description("게시글 생성 시간")
+              )));
+    }
+
+    @Test
+    @DisplayName("ID로 변환할 수 없으면 예외가 발생한다.")
+    void should_throwException_when_IdNotConvert() throws Exception {
+      mockingAuth();
+
+      callGetThumbnailsApi("hello")
+          .andExpect(status().isBadRequest());
+    }
+
+    private ResultActions callGetThumbnailsApi(String id) throws Exception {
+      return mockMvc.perform(get("/posts/users/{id}/thumbnails", id)
+              .cookie(new Cookie(ACCESS_TOKEN.getName(), "token"))
+              .param("page", "0")
+              .param("size", "2"))
+          .andDo(print());
+    }
+  }
+}

--- a/src/test/java/com/dinosaur/foodbowl/domain/post/application/PostServiceTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/post/application/PostServiceTest.java
@@ -1,0 +1,37 @@
+package com.dinosaur.foodbowl.domain.post.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dinosaur.foodbowl.IntegrationTest;
+import com.dinosaur.foodbowl.domain.post.dto.response.PostThumbnailResponseDto;
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+class PostServiceTest extends IntegrationTest {
+
+  @Nested
+  @DisplayName("게시글 썸네일 불러오기")
+  class GetThumbnails {
+
+    @Test
+    @DisplayName("지정한 페이지 설정으로 게시글 썸네일 목록을 불러온다.")
+    void should_loadThumbnails_with_pageable_when_getThumbnails() {
+      User user = userTestHelper.builder().build();
+
+      for (int i = 0; i < 5; i++) {
+        postTestHelper.builder().user(user).content("test" + i).build();
+      }
+
+      Pageable pageable = PageRequest.of(1, 2, Sort.by("id").descending());
+      List<PostThumbnailResponseDto> response = postService.getThumbnails(user.getId(), pageable);
+
+      assertThat(response.size()).isEqualTo(2);
+    }
+  }
+}

--- a/src/test/java/com/dinosaur/foodbowl/domain/post/dao/PostRepositoryTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/post/dao/PostRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.dinosaur.foodbowl.domain.post.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dinosaur.foodbowl.IntegrationTest;
+import com.dinosaur.foodbowl.domain.post.entity.Post;
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+class PostRepositoryTest extends IntegrationTest {
+
+  @Nested
+  @DisplayName("유저 게시글 페이징 검색")
+  class FindAllByUserWithPageable {
+
+    @Test
+    @DisplayName("해당 유저에 대한 게시글만 가져온다.")
+    void should_getOnlyUser_when_findPosts() {
+      User user1 = userTestHelper.builder().build();
+      User user2 = userTestHelper.builder().build();
+      Post post1 = postTestHelper.builder().user(user1).content("post1").build();
+      Post post2 = postTestHelper.builder().user(user2).content("post2").build();
+
+      Pageable pageable = PageRequest.of(0, 18);
+      List<Post> posts = postRepository.findThumbnailsByUser(user1, pageable);
+
+      assertThat(posts.size()).isEqualTo(1);
+      assertThat(posts.get(0).getUser()).isEqualTo(user1);
+      assertThat(posts.get(0).getContent()).isEqualTo(post1.getContent());
+    }
+
+    @Test
+    @DisplayName("설정한 페이지와 크기만큼 가져온다.")
+    void should_pageAndSize_when_pageAndSizeSet() {
+      User user = userTestHelper.builder().build();
+
+      for (int i = 0; i < 10; i++) {
+        postTestHelper.builder().user(user).content("test" + i).build();
+      }
+
+      Pageable pageable = PageRequest.of(1, 3, Sort.by("id").descending());
+      List<Post> posts = postRepository.findThumbnailsByUser(user, pageable);
+
+      assertThat(posts.size()).isEqualTo(3);
+      assertThat(posts.get(0).getContent()).isEqualTo("test6");
+      assertThat(posts.get(1).getContent()).isEqualTo("test5");
+      assertThat(posts.get(2).getContent()).isEqualTo("test4");
+    }
+  }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #24

## 📝 작업 요약

유저 게시글 썸네일 목록을 페이징을 통해 조회하는 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- `Pageable`을 통해 페이징 기능을 구현하였습니다.
- `fetch join`을 통해 게시글 썸네일을 바로 조회할 수 있도록 하였습니다.

## 🌟 리뷰 요구 사항

> 5분
> 페이징 기능을 중점으로 리뷰해주시면 감사합니다 ⛄️