### PR TITLE
Feature/#53 메인 탭 게시글 피드를 불러오는 기능을 구현한다.

### DIFF
--- a/src/docs/asciidoc/post/post.adoc
+++ b/src/docs/asciidoc/post/post.adoc
@@ -46,3 +46,33 @@ include::{snippets}/post-thumbnail-list/http-response.adoc[]
 ==== Response Fields
 
 include::{snippets}/post-thumbnail-list/response-fields.adoc[]
+
+== *게시글 피드 목록 조회*
+
+NOTE: 모든 목록을 조회하는 것이 아닌 페이징을 통한 조회입니다.
+
+=== 요청
+
+==== Request
+
+include::{snippets}/post-feed/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/post-feed/request-cookies.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/post-feed/query-parameters.adoc[]
+
+NOTE: page, size를 지정하지 않아도 디폴트 값으로 처리됩니다.
+
+=== 응답
+
+==== Response
+
+include::{snippets}/post-feed/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/post-feed/response-fields.adoc[]

--- a/src/main/java/com/dinosaur/foodbowl/domain/address/entity/Address.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/address/entity/Address.java
@@ -11,8 +11,10 @@ import java.math.BigDecimal;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @Table(name = "address")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/dinosaur/foodbowl/domain/photo/application/PhotoService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/photo/application/PhotoService.java
@@ -4,7 +4,6 @@ import com.dinosaur.foodbowl.domain.photo.entity.Photo;
 import com.dinosaur.foodbowl.domain.post.entity.Post;
 import java.io.IOException;
 import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.multipart.MultipartFile;
 
 public abstract class PhotoService {

--- a/src/main/java/com/dinosaur/foodbowl/domain/photo/entity/Photo.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/photo/entity/Photo.java
@@ -23,7 +23,8 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 public class Photo extends BaseEntity {
 
-  private static final int MAX_PATH_LENGTH = 512;
+  public static final int MAX_PATH_LENGTH = 512;
+
   @Getter
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/dinosaur/foodbowl/domain/post/api/PostController.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/post/api/PostController.java
@@ -1,7 +1,10 @@
 package com.dinosaur.foodbowl.domain.post.api;
 
 import com.dinosaur.foodbowl.domain.post.application.PostService;
+import com.dinosaur.foodbowl.domain.post.dto.response.PostFeedResponseDto;
 import com.dinosaur.foodbowl.domain.post.dto.response.PostThumbnailResponseDto;
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.dinosaur.foodbowl.global.util.resolver.LoginUser;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -23,8 +26,19 @@ public class PostController {
   @GetMapping("/users/{id}/thumbnails")
   public ResponseEntity<List<PostThumbnailResponseDto>> getThumbnails(
       @PathVariable("id") Long userId,
-      @PageableDefault(size = 18, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+      @PageableDefault(size = 18, sort = "createdAt", direction = Direction.DESC) Pageable pageable
+  ) {
     List<PostThumbnailResponseDto> response = postService.getThumbnails(userId, pageable);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/feed")
+  public ResponseEntity<List<PostFeedResponseDto>> getFeed(
+      @LoginUser User user,
+      @PageableDefault(size = 4, sort = "createdAt", direction = Direction.DESC) Pageable pageable
+  ) {
+    List<PostFeedResponseDto> response = postService.getFeed(user, pageable);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/dinosaur/foodbowl/domain/post/application/PostService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/post/application/PostService.java
@@ -1,6 +1,7 @@
 package com.dinosaur.foodbowl.domain.post.application;
 
 import com.dinosaur.foodbowl.domain.post.dao.PostRepository;
+import com.dinosaur.foodbowl.domain.post.dto.response.PostFeedResponseDto;
 import com.dinosaur.foodbowl.domain.post.dto.response.PostThumbnailResponseDto;
 import com.dinosaur.foodbowl.domain.post.entity.Post;
 import com.dinosaur.foodbowl.domain.user.application.UserFindService;
@@ -27,6 +28,14 @@ public class PostService {
 
     return posts.stream()
         .map(PostThumbnailResponseDto::from)
+        .collect(Collectors.toList());
+  }
+
+  public List<PostFeedResponseDto> getFeed(User user, Pageable pageable) {
+    List<Post> posts = postRepository.findFeed(user, pageable);
+
+    return posts.stream()
+        .map(post -> PostFeedResponseDto.of(post, user))
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/post/dao/PostRepository.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/post/dao/PostRepository.java
@@ -12,4 +12,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
   @Query("select p from Post p left join fetch p.thumbnail where p.user = :user")
   List<Post> findThumbnailsByUser(@Param("user") User user, Pageable pageable);
+
+  @Query("select p from Post p"
+      + " left join fetch p.user"
+      + " left join fetch p.store"
+      + " left join fetch p.store.address"
+      + " where p.user in (select f.following from Follow f where f.follower = :user)"
+      + " or p.user = :user")
+  List<Post> findFeed(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/post/dto/response/PostFeedResponseDto.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/post/dto/response/PostFeedResponseDto.java
@@ -1,0 +1,52 @@
+package com.dinosaur.foodbowl.domain.post.dto.response;
+
+import com.dinosaur.foodbowl.domain.post.entity.Post;
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostFeedResponseDto {
+
+  private final String nickname;
+  private final String thumbnailPath;
+  private final int followerCount;
+  private final List<String> photoPaths;
+  private final String storeName;
+  private final List<String> categories;
+  private final BigDecimal latitude;
+  private final BigDecimal longitude;
+  private final String content;
+  private final int clipCount;
+  private final boolean clipStatus;
+  private final int commentCount;
+  @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+  private final LocalDateTime createdAt;
+
+  public static PostFeedResponseDto of(final Post post, final User user) {
+    return PostFeedResponseDto.builder()
+        .nickname(post.getUser().getNickname().getNickname())
+        .thumbnailPath(post.getUser().getThumbnailURL().orElse(null))
+        .followerCount(post.getUser().getFollowerSize())
+        .photoPaths(post.getPhotoPaths())
+        .storeName(post.getStore().getStoreName())
+        .categories(post.getCategoryNames())
+        .latitude(post.getStore().getAddress().getLatitude())
+        .longitude(post.getStore().getAddress().getLongitude())
+        .content(post.getContent())
+        .clipCount(post.getClipSize())
+        .clipStatus(post.isCliped(user))
+        .commentCount(post.getCommentSize())
+        .createdAt(post.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/dinosaur/foodbowl/domain/post/entity/Post.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/post/entity/Post.java
@@ -1,5 +1,12 @@
 package com.dinosaur.foodbowl.domain.post.entity;
 
+import static jakarta.persistence.CascadeType.REMOVE;
+
+import com.dinosaur.foodbowl.domain.category.entity.Category;
+import com.dinosaur.foodbowl.domain.category.entity.Category.CategoryType;
+import com.dinosaur.foodbowl.domain.clip.entity.Clip;
+import com.dinosaur.foodbowl.domain.comment.entity.Comment;
+import com.dinosaur.foodbowl.domain.photo.entity.Photo;
 import com.dinosaur.foodbowl.domain.store.entity.Store;
 import com.dinosaur.foodbowl.domain.thumbnail.entity.Thumbnail;
 import com.dinosaur.foodbowl.domain.user.entity.User;
@@ -13,8 +20,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -56,11 +67,52 @@ public class Post extends BaseEntity {
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 
+  @OneToMany(mappedBy = "post", cascade = REMOVE)
+  private final List<Photo> photos = new ArrayList<>();
+
+  @OneToMany(mappedBy = "post", cascade = REMOVE)
+  private final List<PostCategory> categories = new ArrayList<>();
+
+  @OneToMany(mappedBy = "post", cascade = REMOVE)
+  private final List<Clip> clips = new ArrayList<>();
+
+  @OneToMany(mappedBy = "post", cascade = REMOVE)
+  private final List<Comment> comments = new ArrayList<>();
+
   @Builder
   private Post(User user, Thumbnail thumbnail, Store store, String content) {
     this.user = user;
     this.thumbnail = thumbnail;
     this.store = store;
     this.content = content;
+  }
+
+  public List<String> getPhotoPaths() {
+    return photos.stream()
+        .map(Photo::getPath)
+        .collect(Collectors.toList());
+  }
+
+  public List<String> getCategoryNames() {
+    return categories.stream()
+        .map(PostCategory::getCategory)
+        .map(Category::getCategoryType)
+        .map(CategoryType::toString)
+        .collect(Collectors.toList());
+  }
+
+  public int getClipSize() {
+    return clips.size();
+  }
+
+  public int getCommentSize() {
+    return comments.size();
+  }
+
+  public boolean isCliped(final User user) {
+    return clips.stream()
+        .filter(clip -> clip.getUser().equals(user))
+        .findAny()
+        .isPresent();
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/post/entity/PostCategory.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/post/entity/PostCategory.java
@@ -14,8 +14,10 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @Table(name = "post_category")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/dinosaur/foodbowl/domain/store/entity/Store.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/store/entity/Store.java
@@ -14,8 +14,10 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @Table(name = "store")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/dinosaur/foodbowl/domain/user/entity/User.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/user/entity/User.java
@@ -72,7 +72,10 @@ public class User extends BaseEntity {
   private final Set<UserRole> userRole = new HashSet<>();
 
   @OneToMany(mappedBy = "follower", cascade = ALL, orphanRemoval = true)
-  private final Set<Follow> followingList = new HashSet<>();
+  private final Set<Follow> following = new HashSet<>();
+
+  @OneToMany(mappedBy = "following", cascade = REMOVE)
+  private final Set<Follow> follower = new HashSet<>();
 
   @OneToMany(mappedBy = "user", cascade = REMOVE)
   private final List<Post> posts = new ArrayList<>();
@@ -116,22 +119,26 @@ public class User extends BaseEntity {
   }
 
   public void follow(User other) {
-    followingList.add(Follow.builder()
+    following.add(Follow.builder()
         .follower(this)
         .following(other)
         .build());
   }
 
   public void unfollow(User other) {
-    followingList.removeIf(follow -> follow.getFollowing().equals(other));
+    following.removeIf(follow -> follow.getFollowing().equals(other));
   }
 
   public boolean isFollowing(User other) {
-    return followingList.stream()
+    return following.stream()
         .anyMatch(follow -> follow.getFollowing().equals(other));
   }
 
   public long getPostCount() {
     return posts.size();
+  }
+
+  public int getFollowerSize() {
+    return follower.size();
   }
 }

--- a/src/test/java/com/dinosaur/foodbowl/IntegrationTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/IntegrationTest.java
@@ -23,10 +23,12 @@ import com.dinosaur.foodbowl.domain.comment.CommentTestHelper;
 import com.dinosaur.foodbowl.domain.comment.application.CommentFindService;
 import com.dinosaur.foodbowl.domain.comment.application.CommentService;
 import com.dinosaur.foodbowl.domain.comment.dao.CommentRepository;
+import com.dinosaur.foodbowl.domain.follow.FollowTestHelper;
 import com.dinosaur.foodbowl.domain.follow.application.FollowService;
 import com.dinosaur.foodbowl.domain.follow.dao.FollowRepository;
 import com.dinosaur.foodbowl.domain.photo.application.file.PhotoFileService;
 import com.dinosaur.foodbowl.domain.photo.application.file.PhotoTestHelper;
+import com.dinosaur.foodbowl.domain.post.PostCategoryTestHelper;
 import com.dinosaur.foodbowl.domain.post.PostTestHelper;
 import com.dinosaur.foodbowl.domain.post.application.PostFindService;
 import com.dinosaur.foodbowl.domain.post.application.PostService;
@@ -176,6 +178,12 @@ public class IntegrationTest {
 
   @Autowired
   protected ClipTestHelper clipTestHelper;
+
+  @Autowired
+  protected FollowTestHelper followTestHelper;
+
+  @Autowired
+  protected PostCategoryTestHelper postCategoryTestHelper;
 
   /******* Util *******/
   @SpyBean

--- a/src/test/java/com/dinosaur/foodbowl/domain/category/entity/CategoryTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/category/entity/CategoryTest.java
@@ -30,5 +30,4 @@ class CategoryTest extends IntegrationTest {
       }
     }
   }
-
 }

--- a/src/test/java/com/dinosaur/foodbowl/domain/follow/FollowTestHelper.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/follow/FollowTestHelper.java
@@ -1,0 +1,48 @@
+package com.dinosaur.foodbowl.domain.follow;
+
+import com.dinosaur.foodbowl.domain.follow.dao.FollowRepository;
+import com.dinosaur.foodbowl.domain.follow.entity.Follow;
+import com.dinosaur.foodbowl.domain.user.UserTestHelper;
+import com.dinosaur.foodbowl.domain.user.entity.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FollowTestHelper {
+
+  @Autowired
+  private FollowRepository followRepository;
+
+  @Autowired
+  private UserTestHelper userTestHelper;
+
+  public FollowBuilder builder() {
+    return new FollowBuilder();
+  }
+
+  public final class FollowBuilder {
+
+    private User following;
+    private User follower;
+
+    private FollowBuilder() {
+    }
+
+    public FollowBuilder following(User user) {
+      this.following = user;
+      return this;
+    }
+
+    public FollowBuilder follower(User user) {
+      this.follower = user;
+      return this;
+    }
+
+    public Follow build() {
+      return followRepository.save(Follow.builder()
+          .following(following != null ? following : userTestHelper.builder().build())
+          .follower(follower != null ? follower : userTestHelper.builder().build())
+          .build());
+    }
+  }
+}

--- a/src/test/java/com/dinosaur/foodbowl/domain/photo/application/file/PhotoTestHelper.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/photo/application/file/PhotoTestHelper.java
@@ -1,8 +1,12 @@
 package com.dinosaur.foodbowl.domain.photo.application.file;
 
 import com.dinosaur.foodbowl.domain.photo.dao.PhotoRepository;
+import com.dinosaur.foodbowl.domain.photo.entity.Photo;
+import com.dinosaur.foodbowl.domain.post.PostTestHelper;
+import com.dinosaur.foodbowl.domain.post.entity.Post;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.stereotype.Component;
@@ -11,7 +15,10 @@ import org.springframework.stereotype.Component;
 public class PhotoTestHelper {
 
   @Autowired
-  PhotoRepository photoRepository;
+  private PhotoRepository photoRepository;
+
+  @Autowired
+  private PostTestHelper postTestHelper;
 
   public MockMultipartFile getImageFile() {
     try {
@@ -37,6 +44,43 @@ public class PhotoTestHelper {
           new FileInputStream("src/test/resources/images/testImage_1x1.png"));
     } catch (IOException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  public PhotoBuilder builder() {
+    return new PhotoBuilder();
+  }
+
+  private String getRandomUUIDLengthWith(int length) {
+    String randomString = UUID.randomUUID()
+        .toString();
+    length = Math.min(length, randomString.length());
+    return randomString.substring(0, length);
+  }
+
+  public final class PhotoBuilder {
+
+    private Post post;
+    private String path;
+
+    private PhotoBuilder() {
+    }
+
+    public PhotoBuilder post(Post post) {
+      this.post = post;
+      return this;
+    }
+
+    public PhotoBuilder path(String path) {
+      this.path = path;
+      return this;
+    }
+
+    public Photo build() {
+      return photoRepository.save(Photo.builder()
+          .post(post != null ? post : postTestHelper.builder().build())
+          .path(path != null ? path : getRandomUUIDLengthWith(Photo.MAX_PATH_LENGTH))
+          .build());
     }
   }
 }

--- a/src/test/java/com/dinosaur/foodbowl/domain/post/PostCategoryTestHelper.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/post/PostCategoryTestHelper.java
@@ -1,0 +1,52 @@
+package com.dinosaur.foodbowl.domain.post;
+
+import com.dinosaur.foodbowl.domain.category.CategoryTestHelper;
+import com.dinosaur.foodbowl.domain.category.entity.Category;
+import com.dinosaur.foodbowl.domain.post.dao.PostCategoryRepository;
+import com.dinosaur.foodbowl.domain.post.entity.Post;
+import com.dinosaur.foodbowl.domain.post.entity.PostCategory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostCategoryTestHelper {
+
+  @Autowired
+  private PostCategoryRepository postCategoryRepository;
+
+  @Autowired
+  private PostTestHelper postTestHelper;
+
+  @Autowired
+  private CategoryTestHelper categoryTestHelper;
+
+  public PostCategoryBuilder builder() {
+    return new PostCategoryBuilder();
+  }
+
+  public final class PostCategoryBuilder {
+
+    private Post post;
+    private Category category;
+
+    private PostCategoryBuilder() {
+    }
+
+    public PostCategoryBuilder post(Post post) {
+      this.post = post;
+      return this;
+    }
+
+    public PostCategoryBuilder category(Category category) {
+      this.category = category;
+      return this;
+    }
+
+    public PostCategory build() {
+      return postCategoryRepository.save(PostCategory.builder()
+          .post(post != null ? post : postTestHelper.builder().build())
+          .category(category != null ? category : categoryTestHelper.generateRandomCategory())
+          .build());
+    }
+  }
+}

--- a/src/test/java/com/dinosaur/foodbowl/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/post/api/PostControllerTest.java
@@ -18,8 +18,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dinosaur.foodbowl.IntegrationTest;
+import com.dinosaur.foodbowl.domain.post.dto.response.PostFeedResponseDto;
 import com.dinosaur.foodbowl.domain.post.dto.response.PostThumbnailResponseDto;
+import com.dinosaur.foodbowl.domain.user.entity.User;
 import jakarta.servlet.http.Cookie;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -100,6 +103,82 @@ class PostControllerTest extends IntegrationTest {
               .cookie(new Cookie(ACCESS_TOKEN.getName(), "token"))
               .param("page", "0")
               .param("size", "2"))
+          .andDo(print());
+    }
+  }
+
+  @Nested
+  @DisplayName("유저 게시글 피드 목록 불러오기")
+  class GetFeed {
+
+    @Test
+    @DisplayName("게시글 피드 목록 불러오기 성공")
+    void should_success_when_getFeed() throws Exception {
+      mockingAuth();
+
+      PostFeedResponseDto mockResponse = PostFeedResponseDto.builder()
+          .nickname("홍길동")
+          .thumbnailPath("ThumbnailPath")
+          .followerCount(100)
+          .photoPaths(List.of("PhotoPath1", "PhotoPath2"))
+          .storeName("틈새라면 홍대점")
+          .categories(List.of("일식"))
+          .latitude(new BigDecimal(17.561))
+          .longitude(new BigDecimal(18.9078))
+          .content("학교 앞에 생겼는데 너무 맛있어요!")
+          .clipCount(4)
+          .clipStatus(false)
+          .commentCount(51)
+          .createdAt(LocalDateTime.now())
+          .build();
+
+      doReturn(List.of(mockResponse)).when(postService)
+          .getFeed(any(User.class), any(Pageable.class));
+
+      callGetFeedApi()
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("[0].nickname").value("홍길동"))
+          .andExpect(jsonPath("[0].thumbnailPath").value("ThumbnailPath"))
+          .andExpect(jsonPath("[0].followerCount").value(100))
+          .andExpect(jsonPath("[0].storeName").value("틈새라면 홍대점"))
+          .andExpect(jsonPath("[0].latitude").value(new BigDecimal(17.561)))
+          .andExpect(jsonPath("[0].longitude").value(new BigDecimal(18.9078)))
+          .andExpect(jsonPath("[0].content").value("학교 앞에 생겼는데 너무 맛있어요!"))
+          .andExpect(jsonPath("[0].clipCount").value(4))
+          .andExpect(jsonPath("[0].clipStatus").value(false))
+          .andExpect(jsonPath("[0].commentCount").value(51))
+          .andDo(document("post-feed",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getName()).description("사용자 인증에 필요한 access token")
+              ),
+              queryParameters(
+                  parameterWithName("page").optional()
+                      .description("불러오고 싶은 피드 목록 페이지 +\n(default: 0)"),
+                  parameterWithName("size").optional()
+                      .description("불러오고 싶은 피드 목록 크기 +\n(default: 4)")
+              ),
+              responseFields(
+                  fieldWithPath("[].nickname").description("게시글 작성자 닉네임"),
+                  fieldWithPath("[].thumbnailPath").description("게시글 작성자 썸네일 URI"),
+                  fieldWithPath("[].followerCount").description("게시글 작성자 팔로워 수"),
+                  fieldWithPath("[].photoPaths").description("게시글 사진 URI 목록"),
+                  fieldWithPath("[].storeName").description("가게 이름"),
+                  fieldWithPath("[].categories").description("카테고리 이름 목록"),
+                  fieldWithPath("[].latitude").description("가게 위도"),
+                  fieldWithPath("[].longitude").description("가게 경도"),
+                  fieldWithPath("[].content").description("게시글 내용"),
+                  fieldWithPath("[].clipCount").description("게시글 스크랩 수"),
+                  fieldWithPath("[].clipStatus").description("게시글 스크랩 여부"),
+                  fieldWithPath("[].commentCount").description("게시글 댓글 수"),
+                  fieldWithPath("[].createdAt").description("게시글 작성 날짜")
+              )));
+    }
+
+    private ResultActions callGetFeedApi() throws Exception {
+      return mockMvc.perform(get("/posts/feed")
+              .cookie(new Cookie(ACCESS_TOKEN.getName(), "token"))
+              .param("page", "0")
+              .param("size", "4"))
           .andDo(print());
     }
   }

--- a/src/test/java/com/dinosaur/foodbowl/domain/post/application/PostServiceTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/post/application/PostServiceTest.java
@@ -3,9 +3,12 @@ package com.dinosaur.foodbowl.domain.post.application;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.dinosaur.foodbowl.IntegrationTest;
+import com.dinosaur.foodbowl.domain.post.dto.response.PostFeedResponseDto;
 import com.dinosaur.foodbowl.domain.post.dto.response.PostThumbnailResponseDto;
+import com.dinosaur.foodbowl.domain.post.entity.Post;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,6 +35,55 @@ class PostServiceTest extends IntegrationTest {
       List<PostThumbnailResponseDto> response = postService.getThumbnails(user.getId(), pageable);
 
       assertThat(response.size()).isEqualTo(2);
+    }
+  }
+
+  @Nested
+  @DisplayName("게시글 피드 불러오기")
+  class GetFeed {
+
+    private User user;
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+      user = userTestHelper.builder().build();
+      User user2 = userTestHelper.builder().build();
+
+      followTestHelper.builder().following(user2).follower(user).build();
+
+      post = postTestHelper.builder().user(user2).content("테스트 게시글").build();
+
+      photoTestHelper.builder().post(post).build();
+      photoTestHelper.builder().post(post).build();
+
+      postCategoryTestHelper.builder().post(post).build();
+      postCategoryTestHelper.builder().post(post).build();
+
+      clipTestHelper.builder().post(post).build();
+      clipTestHelper.builder().post(post).build();
+
+      commentTestHelper.builder().post(post).build();
+      commentTestHelper.builder().post(post).build();
+    }
+
+    @Test
+    @DisplayName("나와 내가 팔로우하고 있는 유저의 게시글만 불러온다.")
+    void should_find_onlyPostsMeAndFollowingUser() {
+      em.flush();
+      em.clear();
+
+      Pageable pageable = PageRequest.of(0, 3, Sort.by("id").descending());
+
+      List<PostFeedResponseDto> response = postService.getFeed(user, pageable);
+
+      assertThat(response).hasSize(1);
+      assertThat(response.get(0).getContent()).isEqualTo("테스트 게시글");
+      assertThat(response.get(0).getFollowerCount()).isEqualTo(1);
+      assertThat(response.get(0).getPhotoPaths()).hasSize(2);
+      assertThat(response.get(0).getCategories()).hasSize(2);
+      assertThat(response.get(0).getClipCount()).isEqualTo(2);
+      assertThat(response.get(0).getCommentCount()).isEqualTo(2);
     }
   }
 }

--- a/src/test/java/com/dinosaur/foodbowl/domain/post/dao/PostRepositoryTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/post/dao/PostRepositoryTest.java
@@ -6,6 +6,7 @@ import com.dinosaur.foodbowl.IntegrationTest;
 import com.dinosaur.foodbowl.domain.post.entity.Post;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -51,6 +52,47 @@ class PostRepositoryTest extends IntegrationTest {
       assertThat(posts.get(0).getContent()).isEqualTo("test6");
       assertThat(posts.get(1).getContent()).isEqualTo("test5");
       assertThat(posts.get(2).getContent()).isEqualTo("test4");
+    }
+  }
+
+  @Nested
+  @DisplayName("유저 피드 페이징 검색")
+  class FindFeed {
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+      user = userTestHelper.builder().build();
+      User user2 = userTestHelper.builder().build();
+      User user3 = userTestHelper.builder().build();
+
+      followTestHelper.builder().following(user2).follower(user).build();
+
+      postTestHelper.builder().user(user).content("유저1 포스트1").build();
+      postTestHelper.builder().user(user2).content("유저2 포스트1").build();
+      postTestHelper.builder().user(user3).content("유저3 포스트1").build();
+
+      postTestHelper.builder().user(user).content("유저1 포스트2").build();
+      postTestHelper.builder().user(user2).content("유저2 포스트2").build();
+      postTestHelper.builder().user(user3).content("유저3 포스트2").build();
+
+      postTestHelper.builder().user(user).content("유저1 포스트3").build();
+      postTestHelper.builder().user(user2).content("유저2 포스트3").build();
+      postTestHelper.builder().user(user3).content("유저3 포스트3").build();
+    }
+
+    @Test
+    @DisplayName("나와 내가 팔로우하고 있는 유저의 게시글만 불러온다.")
+    void should_find_onlyPostsMeAndFollowingUser() {
+      Pageable pageable = PageRequest.of(0, 3, Sort.by("id").descending());
+
+      List<Post> feed = postRepository.findFeed(user, pageable);
+
+      assertThat(feed).hasSize(3);
+      assertThat(feed.get(0).getContent()).isEqualTo("유저2 포스트3");
+      assertThat(feed.get(1).getContent()).isEqualTo("유저1 포스트3");
+      assertThat(feed.get(2).getContent()).isEqualTo("유저2 포스트2");
     }
   }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #53

## 📝 작업 요약

메인 탭의 게시글 피드 목록을 불러오는 기능을 구현하였습니다.

## 🔎 작업 상세 설명

`@ManyToOne` 연관관계는 `fetch join`을 사용하고, `@OneToMany` 연관관계는 `default fetch size`를 활용하였습니다.

## 🌟 리뷰 요구 사항

> 10분
> 가져와야할 정보가 많아져서 `dto`가 커지게 되는데 조금 더 좋은 코드를 작성하기 위한 방법이 없을지 궁금합니다.