### PR TITLE
Feature/#91 북마크한 게시글 썸네일 목록을 조회하는 기능을 구현한다.

### DIFF
--- a/src/docs/asciidoc/clip/clip.adoc
+++ b/src/docs/asciidoc/clip/clip.adoc
@@ -64,3 +64,29 @@ include::{snippets}/unclip/http-response.adoc[]
 ==== Response Fields
 
 include::{snippets}/unclip/response-fields.adoc[]
+
+== *북마크 게시글 썸네일 목록 조회*
+
+=== 요청
+
+==== Request
+
+include::{snippets}/clip-post-thumbnail-list/http-request.adoc[]
+
+==== Request Cookies
+
+include::{snippets}/clip-post-thumbnail-list/request-cookies.adoc[]
+
+==== Query Parameters
+
+include::{snippets}/clip-post-thumbnail-list/query-parameters.adoc[]
+
+=== 응답
+
+==== Response
+
+include::{snippets}/clip-post-thumbnail-list/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/clip-post-thumbnail-list/response-fields.adoc[]

--- a/src/main/java/com/dinosaur/foodbowl/domain/clip/api/ClipController.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/clip/api/ClipController.java
@@ -1,11 +1,17 @@
 package com.dinosaur.foodbowl.domain.clip.api;
 
 import com.dinosaur.foodbowl.domain.clip.application.ClipService;
+import com.dinosaur.foodbowl.domain.clip.dto.response.ClipPostThumbnailResponse;
 import com.dinosaur.foodbowl.domain.clip.dto.response.ClipStatusResponseDto;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import com.dinosaur.foodbowl.global.util.resolver.LoginUser;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +36,17 @@ public class ClipController {
   public ResponseEntity<ClipStatusResponseDto> unclip(@PathVariable("id") Long postId,
       @LoginUser User user) {
     ClipStatusResponseDto response = clipService.unclip(user, postId);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/thumbnails")
+  public ResponseEntity<List<ClipPostThumbnailResponse>> getClipPostThumbnails(
+      @LoginUser User user,
+      @PageableDefault(size = 18, sort = "createdAt", direction = Direction.DESC) Pageable pageable
+  ) {
+    final List<ClipPostThumbnailResponse> response = clipService.getClipPostThumbnails(user,
+        pageable);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/dinosaur/foodbowl/domain/clip/application/ClipService.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/clip/application/ClipService.java
@@ -1,13 +1,17 @@
 package com.dinosaur.foodbowl.domain.clip.application;
 
 import com.dinosaur.foodbowl.domain.clip.dao.ClipRepository;
+import com.dinosaur.foodbowl.domain.clip.dto.response.ClipPostThumbnailResponse;
 import com.dinosaur.foodbowl.domain.clip.dto.response.ClipStatusResponseDto;
 import com.dinosaur.foodbowl.domain.clip.entity.Clip;
 import com.dinosaur.foodbowl.domain.post.application.PostFindService;
 import com.dinosaur.foodbowl.domain.post.entity.Post;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,5 +47,21 @@ public class ClipService {
     }
 
     return ClipStatusResponseDto.from("ok");
+  }
+
+  public List<ClipPostThumbnailResponse> getClipPostThumbnails(
+      final User user, final Pageable pageable
+  ) {
+    final List<Clip> clips = clipRepository.findClipByUser(user, pageable);
+
+    final List<ClipPostThumbnailResponse> response = new ArrayList<>();
+
+    for (final Clip clip : clips) {
+      final Long clipId = clip.getId();
+      final String thumbnailPath = clip.getPost().getThumbnail().getPath();
+      response.add(new ClipPostThumbnailResponse(clipId, thumbnailPath));
+    }
+
+    return response;
   }
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/clip/dao/ClipRepository.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/clip/dao/ClipRepository.java
@@ -3,12 +3,23 @@ package com.dinosaur.foodbowl.domain.clip.dao;
 import com.dinosaur.foodbowl.domain.clip.entity.Clip;
 import com.dinosaur.foodbowl.domain.post.entity.Post;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
+import org.springframework.data.repository.Repository;
 
-public interface ClipRepository extends JpaRepository<Clip, Long> {
+public interface ClipRepository extends Repository<Clip, Long> {
+
+  Clip save(Clip save);
+
+  void delete(Clip clip);
 
   boolean existsClipByUserAndPost(User user, Post post);
 
   Optional<Clip> findClipByUserAndPost(User user, Post post);
+
+  @EntityGraph(attributePaths = {"post", "post.thumbnail"}, type = EntityGraphType.LOAD)
+  List<Clip> findClipByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/dinosaur/foodbowl/domain/clip/dto/response/ClipPostThumbnailResponse.java
+++ b/src/main/java/com/dinosaur/foodbowl/domain/clip/dto/response/ClipPostThumbnailResponse.java
@@ -1,0 +1,5 @@
+package com.dinosaur.foodbowl.domain.clip.dto.response;
+
+public record ClipPostThumbnailResponse(Long clipId, String thumbnailPath) {
+
+}

--- a/src/test/java/com/dinosaur/foodbowl/domain/clip/api/ClipControllerTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/clip/api/ClipControllerTest.java
@@ -7,22 +7,27 @@ import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dinosaur.foodbowl.IntegrationTest;
+import com.dinosaur.foodbowl.domain.clip.dto.response.ClipPostThumbnailResponse;
 import com.dinosaur.foodbowl.domain.clip.dto.response.ClipStatusResponseDto;
 import com.dinosaur.foodbowl.domain.user.entity.User;
 import jakarta.servlet.http.Cookie;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.web.servlet.ResultActions;
 
 class ClipControllerTest extends IntegrationTest {
@@ -92,6 +97,52 @@ class ClipControllerTest extends IntegrationTest {
 
     private ResultActions callUnclipApi(String id) throws Exception {
       return mockMvc.perform(post("/clips/posts/{id}/unclip", id)
+              .cookie(new Cookie(ACCESS_TOKEN.getName(), "token")))
+          .andDo(print());
+    }
+  }
+
+  @Nested
+  @DisplayName("특정 사용자의 북마크한 게시글 썸네일 목록 조회 기능")
+  class GetClipPostThumbnails {
+
+    @Test
+    @DisplayName("특정 사용자의 북마크한 게시글 썸네일 목록을 성공적으로 조회한다.")
+    void success_api() throws Exception {
+      mockingAuth();
+
+      List<ClipPostThumbnailResponse> response = List.of(
+          new ClipPostThumbnailResponse(1L, "path1"),
+          new ClipPostThumbnailResponse(2L, "path2")
+      );
+
+      doReturn(response).when(clipService)
+          .getClipPostThumbnails(any(User.class), any(Pageable.class));
+
+      callGetClipPostThumbnailsApi()
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$[0].clipId").value(1L))
+          .andExpect(jsonPath("$[0].thumbnailPath").value("path1"))
+          .andExpect(jsonPath("$[1].clipId").value(2L))
+          .andExpect(jsonPath("$[1].thumbnailPath").value("path2"))
+          .andDo(document("clip-post-thumbnail-list",
+              requestCookies(
+                  cookieWithName(ACCESS_TOKEN.getName()).description("사용자 인증에 필요한 access token")
+              ),
+              queryParameters(
+                  parameterWithName("page").optional()
+                      .description("북마크한 게시글 썸네일 목록 페이지 +\n(default: 0)"),
+                  parameterWithName("size").optional()
+                      .description("북마크한 게시글 썸네일 목록 크기 +\n(default: 18)")
+              ),
+              responseFields(
+                  fieldWithPath("[].clipId").description("북마크 ID"),
+                  fieldWithPath("[].thumbnailPath").description("북마크한 게시글 썸네일 경로")
+              )));
+    }
+
+    private ResultActions callGetClipPostThumbnailsApi() throws Exception {
+      return mockMvc.perform(get("/clips/thumbnails")
               .cookie(new Cookie(ACCESS_TOKEN.getName(), "token")))
           .andDo(print());
     }

--- a/src/test/java/com/dinosaur/foodbowl/domain/clip/application/ClipServiceTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/clip/application/ClipServiceTest.java
@@ -3,14 +3,19 @@ package com.dinosaur.foodbowl.domain.clip.application;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.dinosaur.foodbowl.IntegrationTest;
+import com.dinosaur.foodbowl.domain.clip.dto.response.ClipPostThumbnailResponse;
 import com.dinosaur.foodbowl.domain.clip.dto.response.ClipStatusResponseDto;
 import com.dinosaur.foodbowl.domain.clip.entity.Clip;
 import com.dinosaur.foodbowl.domain.post.entity.Post;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 class ClipServiceTest extends IntegrationTest {
 
@@ -75,6 +80,31 @@ class ClipServiceTest extends IntegrationTest {
 
       assertThat(response.getStatus()).isEqualTo("ok");
       assertThat(findClip).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("특정 사용자의 북마크한 게시글 썸네일 목록 조회 기능")
+  class GetClipPostThumbnails {
+
+    @Test
+    @DisplayName("특정 사용자의 클립 ID, 썸네일 경로 목록을 조회한다.")
+    void should_get_clip_ID_and_thumbnail_path_for_user() {
+      //given
+      User user = userTestHelper.builder().build();
+      Post post = postTestHelper.builder().build();
+      Clip clip = clipTestHelper.builder().user(user).post(post).build();
+
+      Pageable pageable = PageRequest.of(0, 100, Sort.by("id").descending());
+
+      //when
+      List<ClipPostThumbnailResponse> result = clipService.getClipPostThumbnails(user,
+          pageable);
+
+      //then
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).clipId()).isEqualTo(clip.getId());
+      assertThat(result.get(0).thumbnailPath()).isEqualTo(post.getThumbnail().getPath());
     }
   }
 }

--- a/src/test/java/com/dinosaur/foodbowl/domain/clip/dao/ClipRepositoryTest.java
+++ b/src/test/java/com/dinosaur/foodbowl/domain/clip/dao/ClipRepositoryTest.java
@@ -6,10 +6,14 @@ import com.dinosaur.foodbowl.IntegrationTest;
 import com.dinosaur.foodbowl.domain.clip.entity.Clip;
 import com.dinosaur.foodbowl.domain.post.entity.Post;
 import com.dinosaur.foodbowl.domain.user.entity.User;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 class ClipRepositoryTest extends IntegrationTest {
 
@@ -94,6 +98,39 @@ class ClipRepositoryTest extends IntegrationTest {
       Optional<Clip> findClip = clipRepository.findClipByUserAndPost(user, post);
 
       assertThat(findClip).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("특정 사용자의 클립 목록 조회(paging, fetch join)")
+  class FindClipByUser {
+
+    @Test
+    @DisplayName("특정 사용자의 클립 목록만 조회한다.")
+    void should_get_clips_for_user() {
+      //given
+      User user1 = userTestHelper.builder().build();
+      Post post1 = postTestHelper.builder().build();
+      Post post2 = postTestHelper.builder().build();
+      Post post3 = postTestHelper.builder().build();
+      clipTestHelper.builder().user(user1).post(post1).build();
+      Clip clip2 = clipTestHelper.builder().user(user1).post(post2).build();
+      Clip clip3 = clipTestHelper.builder().user(user1).post(post3).build();
+
+      User user2 = userTestHelper.builder().build();
+      Post post4 = postTestHelper.builder().build();
+      postTestHelper.builder().build();
+      clipTestHelper.builder().user(user2).post(post4).build();
+
+      Pageable pageable = PageRequest.of(0, 2, Sort.by("id").descending());
+
+      //when
+      List<Clip> result = clipRepository.findClipByUser(user1, pageable);
+
+      //then
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0)).isEqualTo(clip3);
+      assertThat(result.get(1)).isEqualTo(clip2);
     }
   }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #91

## 📝 작업 요약

특정 사용자의 북마크 게시글 썸네일 목록 조회 기능을 구현하였습니다.

## 🔎 작업 상세 설명

- `@EntityGraph`를 사용해서 `JPQL`을 사용하지 않고, fetch join을 수행하도록 하였고, LOAD 타입을 통해 ReadOnly 속성을 사용하여 성능 향상을 고민해 보았습니다.
- `JpaRepository`를 사용하지 않아야 하는 이유를 이해하고 `Repository`를 사용하도록 수정하였습니다.
- `Dto`에 `Record`를 도입해 보았습니다.

## 🌟 리뷰 요구 사항

> 10분
> 위의 사항에 대해 고민해 보시면 좋을 것 같습니다!